### PR TITLE
Add authentication that validates API keys provided in request headers by using an X-API-KEY header #1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,15 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-security</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
     </dependency>

--- a/src/main/java/org/springframework/samples/petclinic/security/ApiKeyAuthFilter.java
+++ b/src/main/java/org/springframework/samples/petclinic/security/ApiKeyAuthFilter.java
@@ -1,0 +1,66 @@
+package org.springframework.samples.petclinic.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+/**
+ * Filter for API key based authentication. This filter extracts the API key from the
+ * X-API-KEY header and authenticates the request.
+ */
+@Component
+public class ApiKeyAuthFilter extends OncePerRequestFilter {
+
+	private static final String API_KEY_HEADER = "X-API-KEY";
+
+	private final AuthenticationManager authenticationManager;
+
+	public ApiKeyAuthFilter(AuthenticationManager authenticationManager) {
+		this.authenticationManager = authenticationManager;
+	}
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+			throws ServletException, IOException {
+
+		// Extract API key from header
+		String apiKey = request.getHeader(API_KEY_HEADER);
+
+		// If no API key is provided or it's empty, return 401 Unauthorized
+		if (apiKey == null || apiKey.isEmpty()) {
+			response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "API key is missing or empty");
+			return;
+		}
+
+		try {
+			// Create an authentication token with the API key
+			ApiKeyAuthenticationToken authRequest = new ApiKeyAuthenticationToken(apiKey);
+
+			// Attempt to authenticate the token
+			Authentication authentication = authenticationManager.authenticate(authRequest);
+
+			// If authentication is successful, set the authentication in the security
+			// context
+			SecurityContextHolder.getContext().setAuthentication(authentication);
+
+			// Continue with the filter chain
+			filterChain.doFilter(request, response);
+		}
+		catch (AuthenticationException e) {
+			// If authentication fails, clear the security context and send 401
+			// Unauthorized
+			SecurityContextHolder.clearContext();
+			response.sendError(HttpServletResponse.SC_UNAUTHORIZED, e.getMessage());
+		}
+	}
+
+}

--- a/src/main/java/org/springframework/samples/petclinic/security/ApiKeyAuthenticationProvider.java
+++ b/src/main/java/org/springframework/samples/petclinic/security/ApiKeyAuthenticationProvider.java
@@ -1,0 +1,61 @@
+package org.springframework.samples.petclinic.security;
+
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Component;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Authentication provider for API key based authentication. This provider validates API
+ * keys against a predefined set of valid keys.
+ */
+@Component
+public class ApiKeyAuthenticationProvider implements AuthenticationProvider {
+
+	// In-memory map of API keys to client identifiers
+	private final Map<String, String> apiKeys = new HashMap<>();
+
+	public ApiKeyAuthenticationProvider() {
+		apiKeys.put("test-api-key", "petclinic-client");
+	}
+
+	@Override
+	public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+		ApiKeyAuthenticationToken authToken = (ApiKeyAuthenticationToken) authentication;
+		String apiKey = (String) authToken.getCredentials();
+
+		// Check if the API key exists in our map
+		if (apiKey == null || !apiKeys.containsKey(apiKey)) {
+			throw new BadCredentialsException("Invalid API Key");
+		}
+
+		// Get the client identifier associated with this API key
+		String clientId = apiKeys.get(apiKey);
+
+		// Create a fully authenticated token with the ROLE_PARTNER authority
+		return new ApiKeyAuthenticationToken(apiKey, clientId,
+				Collections.singletonList(new SimpleGrantedAuthority("ROLE_PARTNER")));
+	}
+
+	@Override
+	public boolean supports(Class<?> authentication) {
+		return ApiKeyAuthenticationToken.class.isAssignableFrom(authentication);
+	}
+
+	/**
+	 * Adds a new API key to the in-memory store. This method is primarily for testing
+	 * purposes.
+	 * @param apiKey the API key to add
+	 * @param clientId the client identifier associated with the API key
+	 */
+	public void addApiKey(String apiKey, String clientId) {
+		apiKeys.put(apiKey, clientId);
+	}
+
+}

--- a/src/main/java/org/springframework/samples/petclinic/security/ApiKeyAuthenticationToken.java
+++ b/src/main/java/org/springframework/samples/petclinic/security/ApiKeyAuthenticationToken.java
@@ -1,0 +1,72 @@
+package org.springframework.samples.petclinic.security;
+
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * Custom authentication token for API key based authentication. This token is used to
+ * represent an authentication request using an API key.
+ */
+public class ApiKeyAuthenticationToken extends AbstractAuthenticationToken {
+
+	private final String apiKey;
+
+	private final String principal;
+
+	/**
+	 * Creates an unauthenticated token with the provided API key. This constructor is
+	 * used when the token is created from the request.
+	 * @param apiKey the API key from the request
+	 */
+	public ApiKeyAuthenticationToken(String apiKey) {
+		super(Collections.emptyList());
+		this.apiKey = apiKey;
+		this.principal = null;
+		setAuthenticated(false);
+	}
+
+	/**
+	 * Creates an authenticated token with the provided API key, principal, and
+	 * authorities. This constructor is used when the token is authenticated by the
+	 * provider.
+	 * @param apiKey the API key from the request
+	 * @param principal the principal (usually a client ID or name)
+	 * @param authorities the granted authorities
+	 */
+	public ApiKeyAuthenticationToken(String apiKey, String principal,
+			Collection<? extends GrantedAuthority> authorities) {
+		super(authorities);
+		this.apiKey = apiKey;
+		this.principal = principal;
+		setAuthenticated(true);
+	}
+
+	/**
+	 * Creates an authenticated token with the provided API key, principal, and a single
+	 * authority. This is a convenience constructor for when only one authority is needed.
+	 * @param apiKey the API key from the request
+	 * @param principal the principal (usually a client ID or name)
+	 * @param authority the authority to grant
+	 */
+	public ApiKeyAuthenticationToken(String apiKey, String principal, String authority) {
+		super(Collections.singletonList(new SimpleGrantedAuthority(authority)));
+		this.apiKey = apiKey;
+		this.principal = principal;
+		setAuthenticated(true);
+	}
+
+	@Override
+	public Object getCredentials() {
+		return apiKey;
+	}
+
+	@Override
+	public Object getPrincipal() {
+		return principal != null ? principal : apiKey;
+	}
+
+}

--- a/src/main/java/org/springframework/samples/petclinic/security/SecurityConfig.java
+++ b/src/main/java/org/springframework/samples/petclinic/security/SecurityConfig.java
@@ -1,0 +1,53 @@
+package org.springframework.samples.petclinic.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+/**
+ * Security configuration for the application. This class configures the security filter
+ * chain and authentication providers.
+ */
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+	/**
+	 * Configures the default security filter chain. This filter chain is applied to all
+	 * other endpoints and allows public access.
+	 */
+	@Bean
+	public SecurityFilterChain defaultFilterChain(HttpSecurity http, ApiKeyAuthFilter apiKeyAuthFilter)
+			throws Exception {
+		http.authorizeHttpRequests(authorize -> authorize.anyRequest().permitAll())
+			// Add the API key authentication filter before the username/password filter
+			.addFilterBefore(apiKeyAuthFilter, UsernamePasswordAuthenticationFilter.class);
+
+		return http.build();
+	}
+
+	/**
+	 * Configures the authentication manager with the API key authentication provider.
+	 */
+	@Bean
+	public AuthenticationManager authenticationManager(HttpSecurity http,
+			ApiKeyAuthenticationProvider apiKeyAuthenticationProvider) throws Exception {
+		AuthenticationManagerBuilder authenticationManagerBuilder = http
+			.getSharedObject(AuthenticationManagerBuilder.class);
+		authenticationManagerBuilder.authenticationProvider(apiKeyAuthenticationProvider);
+		return authenticationManagerBuilder.build();
+	}
+
+	@Bean
+	public ApiKeyAuthFilter apiKeyAuthFilter(AuthenticationManager authenticationManager) {
+		return new ApiKeyAuthFilter(authenticationManager);
+	}
+
+}

--- a/src/test/java/org/springframework/samples/petclinic/security/ApiKeyAuthenticationTest.java
+++ b/src/test/java/org/springframework/samples/petclinic/security/ApiKeyAuthenticationTest.java
@@ -1,0 +1,107 @@
+package org.springframework.samples.petclinic.security;
+
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.io.IOException;
+import java.security.Principal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Unit tests for API key authentication components using X-API-KEY header.
+ */
+@SpringBootTest
+@Import({ ApiKeyAuthenticationTest.TestController.class })
+public class ApiKeyAuthenticationTest {
+
+	@Autowired
+	private WebApplicationContext context;
+
+	private MockMvc mockMvc;
+
+	private static final String VALID_API_KEY = "test-api-key";
+
+	private static final String INVALID_API_KEY = "invalid-api-key";
+
+	private static final String API_KEY_HEADER = "X-API-KEY";
+
+	@BeforeEach
+	void setUp() {
+		// Clear security context before each test
+		SecurityContextHolder.clearContext();
+
+		// Set up MockMvc with security
+		mockMvc = MockMvcBuilders.webAppContextSetup(context).apply(springSecurity()).build();
+	}
+
+	@Test
+	void testApiKeyAuthentication_ValidKey() throws Exception {
+		// Create a request with a valid API key and verify it's allowed (200 OK)
+		mockMvc.perform(get("/partners/test").header(API_KEY_HEADER, VALID_API_KEY)).andExpect(status().isOk());
+
+		// The 200 OK status confirms that authentication was successful,
+		// as the endpoint is protected and only accessible with a valid API key
+	}
+
+	@Test
+	void testApiKeyAuthentication_InvalidKey() throws Exception {
+		// Create a request with an invalid API key
+		MvcResult result = mockMvc.perform(get("/partners/test").header(API_KEY_HEADER, INVALID_API_KEY))
+			.andExpect(status().isUnauthorized())
+			.andReturn();
+
+		// Verify that the response has an unauthorized status
+		assertEquals(HttpServletResponse.SC_UNAUTHORIZED, result.getResponse().getStatus());
+
+		// Verify that no authentication is in the security context
+		assertNull(SecurityContextHolder.getContext().getAuthentication());
+	}
+
+	@Test
+	void testApiKeyAuthentication_NullKey() throws Exception {
+		// Create a request without an API key
+		MvcResult result = mockMvc.perform(get("/partners/test")).andExpect(status().isUnauthorized()).andReturn();
+
+		// Verify that the response has an unauthorized status
+		assertEquals(HttpServletResponse.SC_UNAUTHORIZED, result.getResponse().getStatus());
+
+		// Verify that no authentication is in the security context
+		assertNull(SecurityContextHolder.getContext().getAuthentication());
+	}
+
+	/**
+	 * Test controller that handles the /partners/test endpoint.
+	 */
+	@RestController
+	static class TestController {
+
+		@GetMapping("/partners/test")
+		public String partnerTest(Principal principal, HttpServletResponse httpServletResponse,
+				@RequestHeader(API_KEY_HEADER) String apiKey) throws IOException {
+			if (principal == null || apiKey == null || apiKey.isEmpty()) {
+				httpServletResponse.sendError(HttpServletResponse.SC_UNAUTHORIZED, "API key is missing or empty");
+				return "Not authenticated";
+			}
+			return principal.getName();
+		}
+
+	}
+
+}


### PR DESCRIPTION
Add authentication that validates API keys provided in request headers by using an X-API-KEY header #1

Implement a custom authentication filter that validates API keys provided in request headers by using an `X-API-KEY` header without maintaining the session state. Add a default api key `test-api-key`.

FAIL_TO_PASS: ApiKeyAuthenticationTest