### PR TITLE
Implement Basic HTTP Authentication using Spring Security with predefined in-memory users. #2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,10 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-security</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-cache</artifactId>
     </dependency>
     <dependency>
@@ -64,6 +68,15 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-thymeleaf</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-security</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-test</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/src/main/java/org/springframework/samples/petclinic/security/SecurityConfig.java
+++ b/src/main/java/org/springframework/samples/petclinic/security/SecurityConfig.java
@@ -1,0 +1,89 @@
+package org.springframework.samples.petclinic.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.SecurityFilterChain;
+
+/**
+ * Security configuration for the application. Implements Basic HTTP Authentication with
+ * in-memory users.
+ */
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+	/**
+	 * Creates and configures the security filter chain. - Configures Basic HTTP
+	 * Authentication - Secures endpoints based on HTTP method and role - Disables CSRF
+	 * for stateless API - Configures stateless session management
+	 * @param http the HttpSecurity to configure
+	 * @return the configured SecurityFilterChain
+	 * @throws Exception if an error occurs
+	 */
+	@Bean
+	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+		http.csrf(AbstractHttpConfigurer::disable)
+			.authorizeHttpRequests(auth -> auth
+				// ADMIN role required for modifying operations
+				.requestMatchers(HttpMethod.POST, "/**")
+				.hasRole("ADMIN")
+				.requestMatchers(HttpMethod.PUT, "/**")
+				.hasRole("ADMIN")
+				.requestMatchers(HttpMethod.DELETE, "/**")
+				.hasRole("ADMIN")
+				// USER role required for read operations
+				.requestMatchers(HttpMethod.GET, "/**")
+				.hasRole("USER")
+				// Any other request requires authentication
+				.anyRequest()
+				.authenticated())
+			.httpBasic(Customizer.withDefaults())
+			.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+
+		return http.build();
+	}
+
+	/**
+	 * Creates an in-memory user details service with predefined users. - Creates an admin
+	 * user with ADMIN role (which includes USER role permissions) - Creates a regular
+	 * user with USER role
+	 * @return the configured InMemoryUserDetailsManager
+	 */
+	@Bean
+	public InMemoryUserDetailsManager userDetailsService() {
+		UserDetails admin = User.builder()
+			.username("admin")
+			.password(passwordEncoder().encode("adminpass"))
+			.roles("ADMIN", "USER")
+			.build();
+
+		UserDetails user = User.builder()
+			.username("user")
+			.password(passwordEncoder().encode("userpass"))
+			.roles("USER")
+			.build();
+
+		return new InMemoryUserDetailsManager(admin, user);
+	}
+
+	/**
+	 * Creates a BCrypt password encoder for secure password hashing.
+	 * @return the configured password encoder
+	 */
+	@Bean
+	public PasswordEncoder passwordEncoder() {
+		return new BCryptPasswordEncoder();
+	}
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -23,3 +23,8 @@ logging.level.org.springframework=INFO
 
 # Maximum time static resources should be cached
 spring.web.resources.cache.cachecontrol.max-age=12h
+
+# Security
+spring.security.user.name=user
+spring.security.user.password=password
+logging.level.org.springframework.security=DEBUG

--- a/src/test/java/org/springframework/samples/petclinic/security/SecurityConfigTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/security/SecurityConfigTests.java
@@ -1,0 +1,155 @@
+package org.springframework.samples.petclinic.security;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Base64;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Integration tests for the security configuration. Tests access to endpoints based on
+ * user roles and HTTP methods.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@Import({ SecurityConfigTests.TestConfig.class, SecurityConfigTests.TestController.class })
+public class SecurityConfigTests {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	private String createBasicAuthHeader(String username, String password) {
+		String auth = username + ":" + password;
+		return "Basic " + Base64.getEncoder().encodeToString(auth.getBytes());
+	}
+
+	@Test
+	public void testGetEndpointWithUserRole() throws Exception {
+		mockMvc
+			.perform(get("/api/example").header(HttpHeaders.AUTHORIZATION, createBasicAuthHeader("user", "userpass")))
+			.andExpect(status().isOk());
+	}
+
+	@Test
+	public void testGetEndpointWithAdminRole() throws Exception {
+		mockMvc
+			.perform(get("/api/example").header(HttpHeaders.AUTHORIZATION, createBasicAuthHeader("admin", "adminpass")))
+			.andExpect(status().isOk());
+	}
+
+	@Test
+	public void testPostEndpointWithUserRole() throws Exception {
+		mockMvc
+			.perform(post("/api/example").header(HttpHeaders.AUTHORIZATION, createBasicAuthHeader("user", "userpass")))
+			.andExpect(status().isForbidden());
+	}
+
+	@Test
+	public void testPostEndpointWithAdminRole() throws Exception {
+		mockMvc
+			.perform(
+					post("/api/example").header(HttpHeaders.AUTHORIZATION, createBasicAuthHeader("admin", "adminpass")))
+			.andExpect(status().isOk());
+	}
+
+	@Test
+	public void testPutEndpointWithUserRole() throws Exception {
+		mockMvc
+			.perform(put("/api/example").header(HttpHeaders.AUTHORIZATION, createBasicAuthHeader("user", "userpass")))
+			.andExpect(status().isForbidden());
+	}
+
+	@Test
+	public void testPutEndpointWithAdminRole() throws Exception {
+		mockMvc
+			.perform(put("/api/example").header(HttpHeaders.AUTHORIZATION, createBasicAuthHeader("admin", "adminpass")))
+			.andExpect(status().isOk());
+	}
+
+	@Test
+	public void testDeleteEndpointWithUserRole() throws Exception {
+		mockMvc
+			.perform(
+					delete("/api/example").header(HttpHeaders.AUTHORIZATION, createBasicAuthHeader("user", "userpass")))
+			.andExpect(status().isForbidden());
+	}
+
+	@Test
+	public void testDeleteEndpointWithAdminRole() throws Exception {
+		mockMvc
+			.perform(delete("/api/example").header(HttpHeaders.AUTHORIZATION,
+					createBasicAuthHeader("admin", "adminpass")))
+			.andExpect(status().isOk());
+	}
+
+	@Test
+	public void testUnauthorizedAccess() throws Exception {
+		mockMvc.perform(get("/api/example")).andExpect(status().isUnauthorized());
+	}
+
+	@Test
+	public void testInvalidCredentials() throws Exception {
+		mockMvc
+			.perform(get("/api/example").header(HttpHeaders.AUTHORIZATION,
+					createBasicAuthHeader("invalid", "credentials")))
+			.andExpect(status().isUnauthorized());
+	}
+
+	@TestConfiguration
+	static class TestConfig {
+
+		@Autowired
+		public void testUserDetailsService(InMemoryUserDetailsManager manager, PasswordEncoder passwordEncoder) {
+			UserDetails admin = User.builder()
+				.username("admin")
+				.password(passwordEncoder.encode("adminpass"))
+				.roles("ADMIN", "USER")
+				.build();
+
+			UserDetails user = User.builder()
+				.username("user")
+				.password(passwordEncoder.encode("userpass"))
+				.roles("USER")
+				.build();
+
+			if (manager.userExists(admin.getUsername())) {
+				manager.deleteUser(admin.getUsername());
+			}
+			manager.createUser(admin);
+			if (manager.userExists(user.getUsername())) {
+				manager.deleteUser(user.getUsername());
+			}
+			manager.createUser(user);
+		}
+
+	}
+
+	@RestController
+	static class TestController {
+
+		@RequestMapping(path = "/api/example",
+				method = { RequestMethod.GET, RequestMethod.POST, RequestMethod.PUT, RequestMethod.DELETE })
+		public String exampleEndpoint() {
+			return "Example endpoint";
+		}
+
+	}
+
+}


### PR DESCRIPTION
Implement Basic HTTP Authentication using Spring Security with predefined in-memory users. #2

Implement Basic HTTP Authentication using Spring Security with predefined in-memory users. Configure 'ADMIN' and 'USER' user roles. Secure all POST, PUT and DELETE endpoints for an ADMIN role. GET endpoints should be secured with a USER role. Ensure the implementation follows Spring Security best practices.

FAIL_TO_PASS: SecurityConfigTests