### PR TITLE
Create REST controllers for pets, visits and owners #27

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/owner/OwnerRestController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/OwnerRestController.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2012-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.samples.petclinic.owner;
+
+import java.net.URI;
+import java.util.Optional;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import jakarta.validation.Valid;
+
+/**
+ * REST controller for accessing owner data
+ *
+ * @author Junie
+ */
+@RestController
+@RequestMapping("/api/owners")
+public class OwnerRestController {
+
+	private final OwnerRepository ownerRepository;
+
+	public OwnerRestController(OwnerRepository ownerRepository) {
+		this.ownerRepository = ownerRepository;
+	}
+
+	/**
+	 * Get all owners or search by last name
+	 * @param lastName the last name to search for (optional)
+	 * @param page the page number (1-based, defaults to 1)
+	 * @param size the page size (defaults to 10)
+	 * @return a list of owners
+	 */
+	@GetMapping
+	public ResponseEntity<Page<Owner>> getOwners(@RequestParam(required = false) String lastName,
+			@RequestParam(defaultValue = "1") int page, @RequestParam(defaultValue = "10") int size) {
+
+		Pageable pageable = PageRequest.of(page - 1, size);
+		Page<Owner> owners;
+
+		if (lastName != null && !lastName.isEmpty()) {
+			owners = this.ownerRepository.findByLastNameStartingWith(lastName, pageable);
+		}
+		else {
+			owners = this.ownerRepository.findAll(pageable);
+		}
+
+		return ResponseEntity.ok(owners);
+	}
+
+	/**
+	 * Get a specific owner by ID
+	 * @param ownerId the owner ID
+	 * @return the owner with the given ID
+	 */
+	@GetMapping("/{ownerId}")
+	public ResponseEntity<Owner> getOwner(@PathVariable("ownerId") int ownerId) {
+		Optional<Owner> owner = this.ownerRepository.findById(ownerId);
+		return owner.map(ResponseEntity::ok).orElse(ResponseEntity.notFound().build());
+	}
+
+	/**
+	 * Create a new owner
+	 * @param owner the owner to create
+	 * @return the created owner
+	 */
+	@PostMapping
+	public ResponseEntity<Object> createOwner(@Valid @RequestBody Owner owner) {
+		if (owner.getId() != null) {
+			return ResponseEntity.badRequest().body("New owner cannot have an ID");
+		}
+
+		Owner savedOwner = this.ownerRepository.save(owner);
+
+		URI location = ServletUriComponentsBuilder.fromCurrentRequest()
+			.path("/{id}")
+			.buildAndExpand(savedOwner.getId())
+			.toUri();
+
+		return ResponseEntity.created(location).body(savedOwner);
+	}
+
+	/**
+	 * Update an existing owner
+	 * @param ownerId the owner ID
+	 * @param ownerDetails the updated owner details
+	 * @return the updated owner
+	 */
+	@PutMapping("/{ownerId}")
+	public ResponseEntity<Object> updateOwner(@PathVariable("ownerId") int ownerId,
+			@Valid @RequestBody Owner ownerDetails) {
+		Optional<Owner> optionalOwner = this.ownerRepository.findById(ownerId);
+		if (optionalOwner.isEmpty()) {
+			return ResponseEntity.notFound().build();
+		}
+
+		Owner owner = optionalOwner.get();
+
+		// Ensure ID matches path variable
+		if (ownerDetails.getId() != null && ownerDetails.getId() != ownerId) {
+			return ResponseEntity.badRequest().body("Owner ID in body must match path variable");
+		}
+
+		// Update owner fields
+		owner.setFirstName(ownerDetails.getFirstName());
+		owner.setLastName(ownerDetails.getLastName());
+		owner.setAddress(ownerDetails.getAddress());
+		owner.setCity(ownerDetails.getCity());
+		owner.setTelephone(ownerDetails.getTelephone());
+
+		Owner updatedOwner = this.ownerRepository.save(owner);
+		return ResponseEntity.ok(updatedOwner);
+	}
+
+	/**
+	 * Delete an owner
+	 * @param ownerId the owner ID
+	 * @return no content if successful
+	 */
+	@DeleteMapping("/{ownerId}")
+	public ResponseEntity<Void> deleteOwner(@PathVariable("ownerId") int ownerId) {
+		if (!this.ownerRepository.existsById(ownerId)) {
+			return ResponseEntity.notFound().build();
+		}
+
+		this.ownerRepository.deleteById(ownerId);
+		return ResponseEntity.noContent().build();
+	}
+
+}

--- a/src/main/java/org/springframework/samples/petclinic/owner/PetRepository.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/PetRepository.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2012-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.samples.petclinic.owner;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+/**
+ * Repository class for <code>Pet</code> domain objects
+ *
+ * @author Junie
+ */
+@Repository
+public interface PetRepository extends JpaRepository<Pet, Integer> {
+
+	/**
+	 * Find all pets for a given owner
+	 * @param ownerId the owner ID
+	 * @return a list of pets
+	 */
+	@Query("SELECT pet FROM Pet pet JOIN Owner owner ON pet.id IN (SELECT p.id FROM owner.pets p) WHERE owner.id = :ownerId")
+	List<Pet> findByOwnerId(@Param("ownerId") Integer ownerId);
+
+}

--- a/src/main/java/org/springframework/samples/petclinic/owner/PetRestController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/PetRestController.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright 2012-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.samples.petclinic.owner;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import jakarta.validation.Valid;
+
+/**
+ * REST controller for accessing pet data
+ *
+ * @author Junie
+ */
+@RestController
+@RequestMapping("/api")
+public class PetRestController {
+
+	private final PetRepository petRepository;
+
+	private final OwnerRepository ownerRepository;
+
+	private final PetTypeRepository petTypeRepository;
+
+	public PetRestController(PetRepository petRepository, OwnerRepository ownerRepository,
+			PetTypeRepository petTypeRepository) {
+		this.petRepository = petRepository;
+		this.ownerRepository = ownerRepository;
+		this.petTypeRepository = petTypeRepository;
+	}
+
+	/**
+	 * Get all pets
+	 * @return a list of all pets
+	 */
+	@GetMapping("/pets")
+	public ResponseEntity<List<Pet>> getAllPets() {
+		List<Pet> pets = this.petRepository.findAll();
+		return ResponseEntity.ok(pets);
+	}
+
+	/**
+	 * Get a specific pet by ID
+	 * @param petId the pet ID
+	 * @return the pet with the given ID
+	 */
+	@GetMapping("/pets/{petId}")
+	public ResponseEntity<Pet> getPet(@PathVariable("petId") int petId) {
+		Optional<Pet> pet = this.petRepository.findById(petId);
+		return pet.map(ResponseEntity::ok).orElse(ResponseEntity.notFound().build());
+	}
+
+	/**
+	 * Get all pets for a specific owner
+	 * @param ownerId the owner ID
+	 * @return a list of pets for the given owner
+	 */
+	@GetMapping("/owners/{ownerId}/pets")
+	public ResponseEntity<List<Pet>> getPetsByOwner(@PathVariable("ownerId") int ownerId) {
+		// Check if owner exists
+		if (!this.ownerRepository.existsById(ownerId)) {
+			return ResponseEntity.notFound().build();
+		}
+
+		List<Pet> pets = this.petRepository.findByOwnerId(ownerId);
+		return ResponseEntity.ok(pets);
+	}
+
+	/**
+	 * Add a new pet to an owner
+	 * @param ownerId the owner ID
+	 * @param pet the pet to add
+	 * @return the created pet
+	 */
+	@PostMapping("/owners/{ownerId}/pets")
+	public ResponseEntity<Object> addPet(@PathVariable("ownerId") int ownerId, @Valid @RequestBody Pet pet) {
+		// Check if owner exists
+		Optional<Owner> optionalOwner = this.ownerRepository.findById(ownerId);
+		if (optionalOwner.isEmpty()) {
+			return ResponseEntity.notFound().build();
+		}
+
+		Owner owner = optionalOwner.get();
+
+		// Validate pet
+		if (pet.getName() == null || pet.getName().trim().isEmpty()) {
+			return ResponseEntity.badRequest().body("Pet name is required");
+		}
+
+		// Check for duplicate pet name
+		if (owner.getPet(pet.getName(), true) != null) {
+			return ResponseEntity.status(HttpStatus.CONFLICT)
+				.body("Pet with name '" + pet.getName() + "' already exists for this owner");
+		}
+
+		// Add pet to owner
+		owner.addPet(pet);
+		this.ownerRepository.save(owner);
+
+		// Create URI for the new resource
+		URI location = ServletUriComponentsBuilder.fromCurrentRequest()
+			.path("/{id}")
+			.buildAndExpand(pet.getId())
+			.toUri();
+
+		return ResponseEntity.created(location).body(pet);
+	}
+
+	/**
+	 * Update an existing pet
+	 * @param petId the pet ID
+	 * @param petDetails the updated pet details
+	 * @return the updated pet
+	 */
+	@PutMapping("/pets/{petId}")
+	public ResponseEntity<Object> updatePet(@PathVariable("petId") int petId, @Valid @RequestBody Pet petDetails) {
+		Optional<Pet> optionalPet = this.petRepository.findById(petId);
+		if (optionalPet.isEmpty()) {
+			return ResponseEntity.notFound().build();
+		}
+
+		Pet pet = optionalPet.get();
+
+		// Find the owner of this pet
+		List<Owner> owners = this.ownerRepository.findAll();
+		Owner petOwner = null;
+		for (Owner owner : owners) {
+			if (owner.getPet(petId) != null) {
+				petOwner = owner;
+				break;
+			}
+		}
+
+		if (petOwner == null) {
+			return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Could not find owner for pet");
+		}
+
+		// Check for duplicate pet name if name is being changed
+		if (!pet.getName().equals(petDetails.getName()) && petOwner.getPet(petDetails.getName(), false) != null) {
+			return ResponseEntity.status(HttpStatus.CONFLICT)
+				.body("Pet with name '" + petDetails.getName() + "' already exists for this owner");
+		}
+
+		// Update pet
+		pet.setName(petDetails.getName());
+		pet.setBirthDate(petDetails.getBirthDate());
+
+		// Update pet type if provided
+		if (petDetails.getType() != null && petDetails.getType().getId() != null) {
+			Optional<PetType> petType = this.petTypeRepository.findById(petDetails.getType().getId());
+			petType.ifPresent(pet::setType);
+		}
+
+		Pet updatedPet = this.petRepository.save(pet);
+		return ResponseEntity.ok(updatedPet);
+	}
+
+	/**
+	 * Delete a pet
+	 * @param petId the pet ID
+	 * @return no content if successful
+	 */
+	@DeleteMapping("/pets/{petId}")
+	public ResponseEntity<Void> deletePet(@PathVariable("petId") int petId) {
+		if (!this.petRepository.existsById(petId)) {
+			return ResponseEntity.notFound().build();
+		}
+
+		// Find the owner of this pet
+		List<Owner> owners = this.ownerRepository.findAll();
+		for (Owner owner : owners) {
+			Pet pet = owner.getPet(petId);
+			if (pet != null) {
+				// Remove pet from owner's collection
+				owner.getPets().remove(pet);
+				this.ownerRepository.save(owner);
+				break;
+			}
+		}
+
+		this.petRepository.deleteById(petId);
+		return ResponseEntity.noContent().build();
+	}
+
+}

--- a/src/main/java/org/springframework/samples/petclinic/owner/VisitRepository.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/VisitRepository.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2012-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.samples.petclinic.owner;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+/**
+ * Repository class for <code>Visit</code> domain objects
+ *
+ * @author Junie
+ */
+@Repository
+public interface VisitRepository extends JpaRepository<Visit, Integer> {
+
+	/**
+	 * Find all visits for a given pet
+	 * @param petId the pet ID
+	 * @return a list of visits
+	 */
+	@Query("SELECT visit FROM Visit visit WHERE visit.id IN (SELECT v.id FROM Pet pet JOIN pet.visits v WHERE pet.id = :petId)")
+	List<Visit> findByPetId(@Param("petId") Integer petId);
+
+}

--- a/src/main/java/org/springframework/samples/petclinic/owner/VisitRestController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/VisitRestController.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2012-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.samples.petclinic.owner;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import jakarta.validation.Valid;
+
+/**
+ * REST controller for accessing visit data
+ *
+ * @author Junie
+ */
+@RestController
+@RequestMapping("/api")
+public class VisitRestController {
+
+	private final VisitRepository visitRepository;
+
+	private final PetRepository petRepository;
+
+	public VisitRestController(VisitRepository visitRepository, PetRepository petRepository) {
+		this.visitRepository = visitRepository;
+		this.petRepository = petRepository;
+	}
+
+	/**
+	 * Get all visits
+	 * @return a list of all visits
+	 */
+	@GetMapping("/visits")
+	public ResponseEntity<List<Visit>> getAllVisits() {
+		List<Visit> visits = this.visitRepository.findAll();
+		return ResponseEntity.ok(visits);
+	}
+
+	/**
+	 * Get a specific visit by ID
+	 * @param visitId the visit ID
+	 * @return the visit with the given ID
+	 */
+	@GetMapping("/visits/{visitId}")
+	public ResponseEntity<Visit> getVisit(@PathVariable("visitId") int visitId) {
+		Optional<Visit> visit = this.visitRepository.findById(visitId);
+		return visit.map(ResponseEntity::ok).orElse(ResponseEntity.notFound().build());
+	}
+
+	/**
+	 * Get all visits for a specific pet
+	 * @param petId the pet ID
+	 * @return a list of visits for the given pet
+	 */
+	@GetMapping("/pets/{petId}/visits")
+	public ResponseEntity<List<Visit>> getVisitsByPet(@PathVariable("petId") int petId) {
+		// Check if pet exists
+		if (!this.petRepository.existsById(petId)) {
+			return ResponseEntity.notFound().build();
+		}
+
+		List<Visit> visits = this.visitRepository.findByPetId(petId);
+		return ResponseEntity.ok(visits);
+	}
+
+	/**
+	 * Add a new visit to a pet
+	 * @param petId the pet ID
+	 * @param visit the visit to add
+	 * @return the created visit
+	 */
+	@PostMapping("/pets/{petId}/visits")
+	public ResponseEntity<Object> addVisit(@PathVariable("petId") int petId, @Valid @RequestBody Visit visit) {
+		// Check if pet exists
+		Optional<Pet> optionalPet = this.petRepository.findById(petId);
+		if (optionalPet.isEmpty()) {
+			return ResponseEntity.notFound().build();
+		}
+
+		Pet pet = optionalPet.get();
+
+		// Validate visit
+		if (visit.getDescription() == null || visit.getDescription().trim().isEmpty()) {
+			return ResponseEntity.badRequest().body("Visit description is required");
+		}
+
+		// Add visit to pet
+		pet.addVisit(visit);
+		this.petRepository.save(pet);
+
+		// Create URI for the new resource
+		URI location = ServletUriComponentsBuilder.fromCurrentRequest()
+			.path("/{id}")
+			.buildAndExpand(visit.getId())
+			.toUri();
+
+		return ResponseEntity.created(location).body(visit);
+	}
+
+	/**
+	 * Update an existing visit
+	 * @param visitId the visit ID
+	 * @param visitDetails the updated visit details
+	 * @return the updated visit
+	 */
+	@PutMapping("/visits/{visitId}")
+	public ResponseEntity<Object> updateVisit(@PathVariable("visitId") int visitId,
+			@Valid @RequestBody Visit visitDetails) {
+		Optional<Visit> optionalVisit = this.visitRepository.findById(visitId);
+		if (optionalVisit.isEmpty()) {
+			return ResponseEntity.notFound().build();
+		}
+
+		Visit visit = optionalVisit.get();
+
+		// Update visit
+		visit.setDate(visitDetails.getDate());
+		visit.setDescription(visitDetails.getDescription());
+
+		Visit updatedVisit = this.visitRepository.save(visit);
+		return ResponseEntity.ok(updatedVisit);
+	}
+
+	/**
+	 * Delete a visit
+	 * @param visitId the visit ID
+	 * @return no content if successful
+	 */
+	@DeleteMapping("/visits/{visitId}")
+	public ResponseEntity<Void> deleteVisit(@PathVariable("visitId") int visitId) {
+		if (!this.visitRepository.existsById(visitId)) {
+			return ResponseEntity.notFound().build();
+		}
+
+		this.visitRepository.deleteById(visitId);
+		return ResponseEntity.noContent().build();
+	}
+
+}

--- a/src/main/resources/static/rest-api-test.http
+++ b/src/main/resources/static/rest-api-test.http
@@ -1,0 +1,126 @@
+# REST API Test File
+# This file contains HTTP requests to test the REST API endpoints
+# You can use tools like IntelliJ IDEA's HTTP Client, Postman, or curl to execute these requests
+
+### Pet Endpoints
+
+# Get all pets
+GET http://localhost:8080/api/pets
+
+###
+# Get a specific pet by ID
+GET http://localhost:8080/api/pets/1
+
+###
+# Get all pets for a specific owner
+GET http://localhost:8080/api/owners/1/pets
+
+###
+# Add a new pet to an owner
+POST http://localhost:8080/api/owners/1/pets
+Content-Type: application/json
+
+{
+  "name": "Fluffy",
+  "birthDate": "2023-01-15",
+  "type": {
+    "id": 1
+  }
+}
+
+###
+# Update an existing pet
+PUT http://localhost:8080/api/pets/1
+Content-Type: application/json
+
+{
+  "name": "Leo Updated",
+  "birthDate": "2020-09-07",
+  "type": {
+    "id": 1
+  }
+}
+
+###
+# Delete a pet
+DELETE http://localhost:8080/api/pets/13
+
+### Owner Endpoints
+
+# Get all owners
+GET http://localhost:8080/api/owners
+
+###
+# Search owners by last name
+GET http://localhost:8080/api/owners?lastName=Davis
+
+###
+# Get a specific owner by ID
+GET http://localhost:8080/api/owners/1
+
+###
+# Create a new owner
+POST http://localhost:8080/api/owners
+Content-Type: application/json
+
+{
+  "firstName": "John",
+  "lastName": "Doe",
+  "address": "123 Main St",
+  "city": "Anytown",
+  "telephone": "1234567890"
+}
+
+###
+# Update an existing owner
+PUT http://localhost:8080/api/owners/1
+Content-Type: application/json
+
+{
+  "firstName": "George",
+  "lastName": "Franklin",
+  "address": "110 W. Liberty St",
+  "city": "Madison",
+  "telephone": "6085551023"
+}
+
+###
+# Delete an owner
+DELETE http://localhost:8080/api/owners/11
+
+### Visit Endpoints
+
+# Get all visits
+GET http://localhost:8080/api/visits
+
+###
+# Get a specific visit by ID
+GET http://localhost:8080/api/visits/1
+
+###
+# Get all visits for a specific pet
+GET http://localhost:8080/api/pets/7/visits
+
+###
+# Add a new visit to a pet
+POST http://localhost:8080/api/pets/7/visits
+Content-Type: application/json
+
+{
+  "date": "2025-07-14",
+  "description": "Annual checkup"
+}
+
+###
+# Update an existing visit
+PUT http://localhost:8080/api/visits/1
+Content-Type: application/json
+
+{
+  "date": "2023-01-02",
+  "description": "rabies shot updated"
+}
+
+###
+# Delete a visit
+DELETE http://localhost:8080/api/visits/4

--- a/src/test/java/org/springframework/samples/petclinic/owner/OwnerRestControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/owner/OwnerRestControllerTests.java
@@ -1,0 +1,313 @@
+/*
+ * Copyright 2012-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.samples.petclinic.owner;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.json.JacksonTester;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.hamcrest.Matchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * Test class for {@link OwnerRestController}
+ */
+@WebMvcTest(OwnerRestController.class)
+class OwnerRestControllerTests {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@MockitoBean
+	private OwnerRepository ownerRepository;
+
+	@BeforeEach
+	void setup() {
+		JacksonTester.initFields(this, new ObjectMapper());
+	}
+
+	@Test
+	void testGetAllOwners() throws Exception {
+		// given
+		Owner owner1 = new Owner();
+		owner1.setId(1);
+		owner1.setFirstName("George");
+		owner1.setLastName("Franklin");
+		owner1.setAddress("110 W. Liberty St.");
+		owner1.setCity("Madison");
+		owner1.setTelephone("6085551023");
+
+		Owner owner2 = new Owner();
+		owner2.setId(2);
+		owner2.setFirstName("Betty");
+		owner2.setLastName("Davis");
+		owner2.setAddress("638 Cardinal Ave.");
+		owner2.setCity("Sun Prairie");
+		owner2.setTelephone("6085551749");
+
+		List<Owner> owners = Arrays.asList(owner1, owner2);
+		Page<Owner> ownersPage = new PageImpl<>(owners, PageRequest.of(0, 10), owners.size());
+
+		given(this.ownerRepository.findAll(any(Pageable.class))).willReturn(ownersPage);
+
+		// when
+		mockMvc.perform(get("/api/owners"))
+			// then
+			.andExpect(status().isOk())
+			.andExpect(content().contentType(MediaType.APPLICATION_JSON))
+			.andExpect(jsonPath("$.content", hasSize(2)))
+			.andExpect(jsonPath("$.content[0].id", is(1)))
+			.andExpect(jsonPath("$.content[0].firstName", is("George")))
+			.andExpect(jsonPath("$.content[0].lastName", is("Franklin")))
+			.andExpect(jsonPath("$.content[1].id", is(2)))
+			.andExpect(jsonPath("$.content[1].firstName", is("Betty")))
+			.andExpect(jsonPath("$.content[1].lastName", is("Davis")));
+	}
+
+	@Test
+	void testGetOwnersByLastName() throws Exception {
+		// given
+		Owner owner = new Owner();
+		owner.setId(2);
+		owner.setFirstName("Betty");
+		owner.setLastName("Davis");
+		owner.setAddress("638 Cardinal Ave.");
+		owner.setCity("Sun Prairie");
+		owner.setTelephone("6085551749");
+
+		List<Owner> owners = List.of(owner);
+		Page<Owner> ownersPage = new PageImpl<>(owners, PageRequest.of(0, 10), owners.size());
+
+		given(this.ownerRepository.findByLastNameStartingWith(eq("Davis"), any(Pageable.class))).willReturn(ownersPage);
+
+		// when
+		mockMvc.perform(get("/api/owners?lastName=Davis"))
+			// then
+			.andExpect(status().isOk())
+			.andExpect(content().contentType(MediaType.APPLICATION_JSON))
+			.andExpect(jsonPath("$.content", hasSize(1)))
+			.andExpect(jsonPath("$.content[0].id", is(2)))
+			.andExpect(jsonPath("$.content[0].firstName", is("Betty")))
+			.andExpect(jsonPath("$.content[0].lastName", is("Davis")));
+	}
+
+	@Test
+	void testGetOwner() throws Exception {
+		// given
+		Owner owner = new Owner();
+		owner.setId(1);
+		owner.setFirstName("George");
+		owner.setLastName("Franklin");
+		owner.setAddress("110 W. Liberty St.");
+		owner.setCity("Madison");
+		owner.setTelephone("6085551023");
+
+		given(this.ownerRepository.findById(1)).willReturn(Optional.of(owner));
+
+		// when
+		mockMvc.perform(get("/api/owners/1"))
+			// then
+			.andExpect(status().isOk())
+			.andExpect(content().contentType(MediaType.APPLICATION_JSON))
+			.andExpect(jsonPath("$.id", is(1)))
+			.andExpect(jsonPath("$.firstName", is("George")))
+			.andExpect(jsonPath("$.lastName", is("Franklin")))
+			.andExpect(jsonPath("$.address", is("110 W. Liberty St.")))
+			.andExpect(jsonPath("$.city", is("Madison")))
+			.andExpect(jsonPath("$.telephone", is("6085551023")));
+	}
+
+	@Test
+	void testGetOwnerNotFound() throws Exception {
+		// given
+		given(this.ownerRepository.findById(999)).willReturn(Optional.empty());
+
+		// when
+		mockMvc.perform(get("/api/owners/999"))
+			// then
+			.andExpect(status().isNotFound());
+	}
+
+	@Test
+	void testCreateOwner() throws Exception {
+		// given
+		Owner newOwner = new Owner();
+		newOwner.setFirstName("John");
+		newOwner.setLastName("Doe");
+		newOwner.setAddress("123 Main St");
+		newOwner.setCity("Anytown");
+		newOwner.setTelephone("1234567890");
+
+		given(this.ownerRepository.save(any(Owner.class))).willAnswer(invocation -> {
+			Owner savedOwner = invocation.getArgument(0);
+			savedOwner.setId(10);
+			return savedOwner;
+		});
+
+		// when
+		mockMvc.perform(post("/api/owners").contentType(MediaType.APPLICATION_JSON)
+			.content(
+					"{\"firstName\":\"John\",\"lastName\":\"Doe\",\"address\":\"123 Main St\",\"city\":\"Anytown\",\"telephone\":\"1234567890\"}"))
+			// then
+			.andExpect(status().isCreated())
+			.andExpect(header().string("Location", containsString("/api/owners/10")))
+			.andExpect(jsonPath("$.id", is(10)))
+			.andExpect(jsonPath("$.firstName", is("John")))
+			.andExpect(jsonPath("$.lastName", is("Doe")))
+			.andExpect(jsonPath("$.address", is("123 Main St")))
+			.andExpect(jsonPath("$.city", is("Anytown")))
+			.andExpect(jsonPath("$.telephone", is("1234567890")));
+
+		verify(this.ownerRepository).save(any(Owner.class));
+	}
+
+	@Test
+	void testCreateOwnerWithId() throws Exception {
+		// when
+		mockMvc.perform(post("/api/owners").contentType(MediaType.APPLICATION_JSON)
+			.content(
+					"{\"id\":1,\"firstName\":\"John\",\"lastName\":\"Doe\",\"address\":\"123 Main St\",\"city\":\"Anytown\",\"telephone\":\"1234567890\"}"))
+			// then
+			.andExpect(status().isBadRequest());
+
+		verify(this.ownerRepository, never()).save(any(Owner.class));
+	}
+
+	@Test
+	void testCreateOwnerInvalidData() throws Exception {
+		// when - missing required fields
+		mockMvc.perform(post("/api/owners").contentType(MediaType.APPLICATION_JSON).content("{\"firstName\":\"John\"}"))
+			// then
+			.andExpect(status().isBadRequest());
+
+		verify(this.ownerRepository, never()).save(any(Owner.class));
+	}
+
+	@Test
+	void testUpdateOwner() throws Exception {
+		// given
+		Owner existingOwner = new Owner();
+		existingOwner.setId(1);
+		existingOwner.setFirstName("George");
+		existingOwner.setLastName("Franklin");
+		existingOwner.setAddress("110 W. Liberty St.");
+		existingOwner.setCity("Madison");
+		existingOwner.setTelephone("6085551023");
+
+		given(this.ownerRepository.findById(1)).willReturn(Optional.of(existingOwner));
+		given(this.ownerRepository.save(any(Owner.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+		// when
+		mockMvc.perform(put("/api/owners/1").contentType(MediaType.APPLICATION_JSON)
+			.content(
+					"{\"firstName\":\"George Updated\",\"lastName\":\"Franklin\",\"address\":\"110 W. Liberty St.\",\"city\":\"Madison\",\"telephone\":\"6085551023\"}"))
+			// then
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.id", is(1)))
+			.andExpect(jsonPath("$.firstName", is("George Updated")))
+			.andExpect(jsonPath("$.lastName", is("Franklin")))
+			.andExpect(jsonPath("$.address", is("110 W. Liberty St.")))
+			.andExpect(jsonPath("$.city", is("Madison")))
+			.andExpect(jsonPath("$.telephone", is("6085551023")));
+
+		verify(this.ownerRepository).save(any(Owner.class));
+	}
+
+	@Test
+	void testUpdateOwnerNotFound() throws Exception {
+		// given
+		given(this.ownerRepository.findById(999)).willReturn(Optional.empty());
+
+		// when
+		mockMvc.perform(put("/api/owners/999").contentType(MediaType.APPLICATION_JSON)
+			.content(
+					"{\"firstName\":\"George Updated\",\"lastName\":\"Franklin\",\"address\":\"110 W. Liberty St.\",\"city\":\"Madison\",\"telephone\":\"6085551023\"}"))
+			// then
+			.andExpect(status().isNotFound());
+
+		verify(this.ownerRepository, never()).save(any(Owner.class));
+	}
+
+	@Test
+	void testUpdateOwnerIdMismatch() throws Exception {
+		// given
+		Owner existingOwner = new Owner();
+		existingOwner.setId(1);
+		existingOwner.setFirstName("George");
+		existingOwner.setLastName("Franklin");
+		existingOwner.setAddress("110 W. Liberty St.");
+		existingOwner.setCity("Madison");
+		existingOwner.setTelephone("6085551023");
+
+		given(this.ownerRepository.findById(1)).willReturn(Optional.of(existingOwner));
+
+		// when
+		mockMvc.perform(put("/api/owners/1").contentType(MediaType.APPLICATION_JSON)
+			.content(
+					"{\"id\":2,\"firstName\":\"George Updated\",\"lastName\":\"Franklin\",\"address\":\"110 W. Liberty St.\",\"city\":\"Madison\",\"telephone\":\"6085551023\"}"))
+			// then
+			.andExpect(status().isBadRequest());
+
+		verify(this.ownerRepository, never()).save(any(Owner.class));
+	}
+
+	@Test
+	void testDeleteOwner() throws Exception {
+		// given
+		given(this.ownerRepository.existsById(1)).willReturn(true);
+
+		// when
+		mockMvc.perform(delete("/api/owners/1"))
+			// then
+			.andExpect(status().isNoContent());
+
+		verify(this.ownerRepository).deleteById(1);
+	}
+
+	@Test
+	void testDeleteOwnerNotFound() throws Exception {
+		// given
+		given(this.ownerRepository.existsById(999)).willReturn(false);
+
+		// when
+		mockMvc.perform(delete("/api/owners/999"))
+			// then
+			.andExpect(status().isNotFound());
+
+		verify(this.ownerRepository, never()).deleteById(anyInt());
+	}
+
+}

--- a/src/test/java/org/springframework/samples/petclinic/owner/PetRestControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/owner/PetRestControllerTests.java
@@ -1,0 +1,492 @@
+/*
+ * Copyright 2012-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.samples.petclinic.owner;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.json.JacksonTester;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.hamcrest.Matchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * Test class for {@link PetRestController}
+ */
+@WebMvcTest(PetRestController.class)
+class PetRestControllerTests {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@MockitoBean
+	private PetRepository petRepository;
+
+	@MockitoBean
+	private OwnerRepository ownerRepository;
+
+	@MockitoBean
+	private PetTypeRepository petTypeRepository;
+
+	@BeforeEach
+	void setup() {
+		JacksonTester.initFields(this, new ObjectMapper());
+	}
+
+	@Test
+	void testGetAllPets() throws Exception {
+		// given
+		PetType dog = new PetType();
+		dog.setId(1);
+		dog.setName("dog");
+
+		Pet pet1 = new Pet();
+		pet1.setId(1);
+		pet1.setName("Leo");
+		pet1.setBirthDate(LocalDate.of(2020, 9, 7));
+		pet1.setType(dog);
+
+		Pet pet2 = new Pet();
+		pet2.setId(2);
+		pet2.setName("Basil");
+		pet2.setBirthDate(LocalDate.of(2012, 8, 6));
+		pet2.setType(dog);
+
+		List<Pet> pets = Arrays.asList(pet1, pet2);
+		given(this.petRepository.findAll()).willReturn(pets);
+
+		// when
+		mockMvc.perform(get("/api/pets"))
+			// then
+			.andExpect(status().isOk())
+			.andExpect(content().contentType(MediaType.APPLICATION_JSON))
+			.andExpect(jsonPath("$", hasSize(2)))
+			.andExpect(jsonPath("$[0].id", is(1)))
+			.andExpect(jsonPath("$[0].name", is("Leo")))
+			.andExpect(jsonPath("$[1].id", is(2)))
+			.andExpect(jsonPath("$[1].name", is("Basil")));
+	}
+
+	@Test
+	void testGetPet() throws Exception {
+		// given
+		PetType dog = new PetType();
+		dog.setId(1);
+		dog.setName("dog");
+
+		Pet pet = new Pet();
+		pet.setId(1);
+		pet.setName("Leo");
+		pet.setBirthDate(LocalDate.of(2020, 9, 7));
+		pet.setType(dog);
+
+		given(this.petRepository.findById(1)).willReturn(Optional.of(pet));
+
+		// when
+		mockMvc.perform(get("/api/pets/1"))
+			// then
+			.andExpect(status().isOk())
+			.andExpect(content().contentType(MediaType.APPLICATION_JSON))
+			.andExpect(jsonPath("$.id", is(1)))
+			.andExpect(jsonPath("$.name", is("Leo")))
+			.andExpect(jsonPath("$.birthDate", is("2020-09-07")))
+			.andExpect(jsonPath("$.type.id", is(1)))
+			.andExpect(jsonPath("$.type.name", is("dog")));
+	}
+
+	@Test
+	void testGetPetNotFound() throws Exception {
+		// given
+		given(this.petRepository.findById(999)).willReturn(Optional.empty());
+
+		// when
+		mockMvc.perform(get("/api/pets/999"))
+			// then
+			.andExpect(status().isNotFound());
+	}
+
+	@Test
+	void testGetPetsByOwner() throws Exception {
+		// given
+		PetType dog = new PetType();
+		dog.setId(1);
+		dog.setName("dog");
+
+		Pet pet1 = new Pet();
+		pet1.setId(1);
+		pet1.setName("Leo");
+		pet1.setBirthDate(LocalDate.of(2020, 9, 7));
+		pet1.setType(dog);
+
+		Pet pet2 = new Pet();
+		pet2.setId(2);
+		pet2.setName("Basil");
+		pet2.setBirthDate(LocalDate.of(2012, 8, 6));
+		pet2.setType(dog);
+
+		List<Pet> pets = Arrays.asList(pet1, pet2);
+		given(this.ownerRepository.existsById(1)).willReturn(true);
+		given(this.petRepository.findByOwnerId(1)).willReturn(pets);
+
+		// when
+		mockMvc.perform(get("/api/owners/1/pets"))
+			// then
+			.andExpect(status().isOk())
+			.andExpect(content().contentType(MediaType.APPLICATION_JSON))
+			.andExpect(jsonPath("$", hasSize(2)))
+			.andExpect(jsonPath("$[0].id", is(1)))
+			.andExpect(jsonPath("$[0].name", is("Leo")))
+			.andExpect(jsonPath("$[1].id", is(2)))
+			.andExpect(jsonPath("$[1].name", is("Basil")));
+	}
+
+	@Test
+	void testGetPetsByOwnerNotFound() throws Exception {
+		// given
+		given(this.ownerRepository.existsById(999)).willReturn(false);
+
+		// when
+		mockMvc.perform(get("/api/owners/999/pets"))
+			// then
+			.andExpect(status().isNotFound());
+	}
+
+	@Test
+	void testAddPet() throws Exception {
+		// given
+		PetType dog = new PetType();
+		dog.setId(1);
+		dog.setName("dog");
+
+		Owner owner = new Owner();
+		owner.setId(1);
+		owner.setFirstName("George");
+		owner.setLastName("Franklin");
+
+		Pet newPet = new Pet();
+		newPet.setName("Leo");
+		newPet.setBirthDate(LocalDate.of(2020, 9, 7));
+		newPet.setType(dog);
+
+		given(this.ownerRepository.findById(1)).willReturn(Optional.of(owner));
+		given(this.ownerRepository.save(any(Owner.class))).willAnswer(invocation -> {
+			Owner savedOwner = invocation.getArgument(0);
+			Pet savedPet = savedOwner.getPets().get(0);
+			savedPet.setId(1);
+			return savedOwner;
+		});
+
+		// when
+		mockMvc
+			.perform(post("/api/owners/1/pets").contentType(MediaType.APPLICATION_JSON)
+				.content("{\"name\":\"Leo\",\"birthDate\":\"2020-09-07\",\"type\":{\"id\":1}}"))
+			// then
+			.andExpect(status().isCreated())
+			.andExpect(header().string("Location", containsString("/api/owners/1/pets/1")))
+			.andExpect(jsonPath("$.name", is("Leo")))
+			.andExpect(jsonPath("$.birthDate", is("2020-09-07")))
+			.andExpect(jsonPath("$.type.id", is(1)));
+
+		verify(this.ownerRepository).save(any(Owner.class));
+	}
+
+	@Test
+	void testAddPetOwnerNotFound() throws Exception {
+		// given
+		given(this.ownerRepository.findById(999)).willReturn(Optional.empty());
+
+		// when
+		mockMvc
+			.perform(post("/api/owners/999/pets").contentType(MediaType.APPLICATION_JSON)
+				.content("{\"name\":\"Leo\",\"birthDate\":\"2020-09-07\",\"type\":{\"id\":1}}"))
+			// then
+			.andExpect(status().isNotFound());
+
+		verify(this.ownerRepository, never()).save(any(Owner.class));
+	}
+
+	@Test
+	void testAddPetInvalidName() throws Exception {
+		// given
+		Owner owner = new Owner();
+		owner.setId(1);
+		owner.setFirstName("George");
+		owner.setLastName("Franklin");
+
+		given(this.ownerRepository.findById(1)).willReturn(Optional.of(owner));
+
+		// when
+		mockMvc
+			.perform(post("/api/owners/1/pets").contentType(MediaType.APPLICATION_JSON)
+				.content("{\"name\":\"\",\"birthDate\":\"2020-09-07\",\"type\":{\"id\":1}}"))
+			// then
+			.andExpect(status().isBadRequest());
+
+		verify(this.ownerRepository, never()).save(any(Owner.class));
+	}
+
+	@Test
+	void testAddPetDuplicateName() throws Exception {
+		// given
+		PetType dog = new PetType();
+		dog.setId(1);
+		dog.setName("dog");
+
+		Pet existingPet = new Pet();
+		existingPet.setId(1);
+		existingPet.setName("Leo");
+		existingPet.setBirthDate(LocalDate.of(2020, 9, 7));
+		existingPet.setType(dog);
+
+		// Create a spy of Owner to control the behavior of getPet method
+		Owner owner = spy(new Owner());
+		owner.setId(1);
+		owner.setFirstName("George");
+		owner.setLastName("Franklin");
+		owner.addPet(existingPet);
+
+		// Mock the behavior that causes the conflict
+		// When owner.getPet("Leo", true) is called, it should return the existing pet
+		doReturn(existingPet).when(owner).getPet(eq("Leo"), eq(true));
+
+		given(this.ownerRepository.findById(1)).willReturn(Optional.of(owner));
+
+		// when
+		mockMvc
+			.perform(post("/api/owners/1/pets").contentType(MediaType.APPLICATION_JSON)
+				.content("{\"name\":\"Leo\",\"birthDate\":\"2020-09-07\",\"type\":{\"id\":1}}"))
+			// then
+			.andExpect(status().isConflict());
+
+		verify(this.ownerRepository, never()).save(any(Owner.class));
+	}
+
+	@Test
+	void testUpdatePet() throws Exception {
+		// given
+		PetType dog = new PetType();
+		dog.setId(1);
+		dog.setName("dog");
+
+		Pet pet = new Pet();
+		pet.setId(1);
+		pet.setName("Leo");
+		pet.setBirthDate(LocalDate.of(2020, 9, 7));
+		pet.setType(dog);
+
+		// Create a spy of Owner to control the behavior of getPet method
+		Owner owner = spy(new Owner());
+		owner.setId(1);
+		owner.setFirstName("George");
+		owner.setLastName("Franklin");
+
+		// We need to manually add the pet to the owner's pets list
+		// and make getPet(1) return the pet
+		List<Pet> pets = new ArrayList<>();
+		pets.add(pet);
+		// Use reflection to set the pets field directly
+		try {
+			java.lang.reflect.Field petsField = Owner.class.getDeclaredField("pets");
+			petsField.setAccessible(true);
+			petsField.set(owner, pets);
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+
+		// Mock the behavior of getPet(1) to return our pet
+		doReturn(pet).when(owner).getPet(eq(1));
+
+		given(this.petRepository.findById(1)).willReturn(Optional.of(pet));
+		given(this.ownerRepository.findAll()).willReturn(List.of(owner));
+		given(this.petTypeRepository.findById(1)).willReturn(Optional.of(dog));
+		given(this.petRepository.save(any(Pet.class))).willAnswer(invocation -> {
+			Pet savedPet = invocation.getArgument(0);
+			savedPet.setName("Leo Updated"); // Ensure the name is updated
+			return savedPet;
+		});
+
+		// when
+		mockMvc
+			.perform(put("/api/pets/1").contentType(MediaType.APPLICATION_JSON)
+				.content("{\"name\":\"Leo Updated\",\"birthDate\":\"2020-09-07\",\"type\":{\"id\":1}}"))
+			// then
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.id", is(1)))
+			.andExpect(jsonPath("$.name", is("Leo Updated")))
+			.andExpect(jsonPath("$.birthDate", is("2020-09-07")))
+			.andExpect(jsonPath("$.type.id", is(1)));
+
+		verify(this.petRepository).save(any(Pet.class));
+	}
+
+	@Test
+	void testUpdatePetNotFound() throws Exception {
+		// given
+		given(this.petRepository.findById(999)).willReturn(Optional.empty());
+
+		// when
+		mockMvc
+			.perform(put("/api/pets/999").contentType(MediaType.APPLICATION_JSON)
+				.content("{\"name\":\"Leo Updated\",\"birthDate\":\"2020-09-07\",\"type\":{\"id\":1}}"))
+			// then
+			.andExpect(status().isNotFound());
+
+		verify(this.petRepository, never()).save(any(Pet.class));
+	}
+
+	@Test
+	void testUpdatePetDuplicateName() throws Exception {
+		// given
+		PetType dog = new PetType();
+		dog.setId(1);
+		dog.setName("dog");
+
+		Pet pet1 = new Pet();
+		pet1.setId(1);
+		pet1.setName("Leo");
+		pet1.setBirthDate(LocalDate.of(2020, 9, 7));
+		pet1.setType(dog);
+
+		Pet pet2 = new Pet();
+		pet2.setId(2);
+		pet2.setName("Basil");
+		pet2.setBirthDate(LocalDate.of(2012, 8, 6));
+		pet2.setType(dog);
+
+		// Create a spy of Owner to control the behavior of getPet methods
+		Owner owner = spy(new Owner());
+		owner.setId(1);
+		owner.setFirstName("George");
+		owner.setLastName("Franklin");
+
+		// We need to manually add both pets to the owner's pets list
+		List<Pet> pets = new ArrayList<>();
+		pets.add(pet1);
+		pets.add(pet2);
+		// Use reflection to set the pets field directly
+		try {
+			java.lang.reflect.Field petsField = Owner.class.getDeclaredField("pets");
+			petsField.setAccessible(true);
+			petsField.set(owner, pets);
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+
+		// Mock the behavior of getPet(1) to return pet1
+		doReturn(pet1).when(owner).getPet(eq(1));
+
+		// Mock the behavior of getPet("Basil", false) to return pet2
+		// This is the key for the duplicate name check
+		doReturn(pet2).when(owner).getPet(eq("Basil"), eq(false));
+
+		given(this.petRepository.findById(1)).willReturn(Optional.of(pet1));
+		given(this.ownerRepository.findAll()).willReturn(List.of(owner));
+
+		// when
+		mockMvc
+			.perform(put("/api/pets/1").contentType(MediaType.APPLICATION_JSON)
+				.content("{\"name\":\"Basil\",\"birthDate\":\"2020-09-07\",\"type\":{\"id\":1}}"))
+			// then
+			.andExpect(status().isConflict());
+
+		verify(this.petRepository, never()).save(any(Pet.class));
+	}
+
+	@Test
+	void testDeletePet() throws Exception {
+		// given
+		PetType dog = new PetType();
+		dog.setId(1);
+		dog.setName("dog");
+
+		Pet pet = new Pet();
+		pet.setId(1);
+		pet.setName("Leo");
+		pet.setBirthDate(LocalDate.of(2020, 9, 7));
+		pet.setType(dog);
+
+		// Create a spy of Owner to control the behavior of getPet method
+		Owner owner = spy(new Owner());
+		owner.setId(1);
+		owner.setFirstName("George");
+		owner.setLastName("Franklin");
+
+		// We need to manually add the pet to the owner's pets list
+		// and make getPet(1) return the pet
+		List<Pet> pets = new ArrayList<>();
+		pets.add(pet);
+		// Use reflection to set the pets field directly
+		try {
+			java.lang.reflect.Field petsField = Owner.class.getDeclaredField("pets");
+			petsField.setAccessible(true);
+			petsField.set(owner, pets);
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+
+		// Mock the behavior of getPet(1) to return our pet
+		doReturn(pet).when(owner).getPet(eq(1));
+
+		given(this.petRepository.existsById(1)).willReturn(true);
+		given(this.ownerRepository.findAll()).willReturn(List.of(owner));
+
+		// Mock the save method to return the owner
+		given(this.ownerRepository.save(any(Owner.class))).willReturn(owner);
+
+		// when
+		mockMvc.perform(delete("/api/pets/1"))
+			// then
+			.andExpect(status().isNoContent());
+
+		verify(this.petRepository).deleteById(1);
+		verify(this.ownerRepository).save(any(Owner.class));
+	}
+
+	@Test
+	void testDeletePetNotFound() throws Exception {
+		// given
+		given(this.petRepository.existsById(999)).willReturn(false);
+
+		// when
+		mockMvc.perform(delete("/api/pets/999"))
+			// then
+			.andExpect(status().isNotFound());
+
+		verify(this.petRepository, never()).deleteById(anyInt());
+		verify(this.ownerRepository, never()).save(any(Owner.class));
+	}
+
+}

--- a/src/test/java/org/springframework/samples/petclinic/owner/VisitRestControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/owner/VisitRestControllerTests.java
@@ -1,0 +1,295 @@
+/*
+ * Copyright 2012-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.samples.petclinic.owner;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.json.JacksonTester;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.hamcrest.Matchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * Test class for {@link VisitRestController}
+ */
+@WebMvcTest(VisitRestController.class)
+class VisitRestControllerTests {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@MockitoBean
+	private VisitRepository visitRepository;
+
+	@MockitoBean
+	private PetRepository petRepository;
+
+	@BeforeEach
+	void setup() {
+		JacksonTester.initFields(this, new ObjectMapper());
+	}
+
+	@Test
+	void testGetAllVisits() throws Exception {
+		// given
+		Visit visit1 = new Visit();
+		visit1.setId(1);
+		visit1.setDate(LocalDate.of(2023, 1, 1));
+		visit1.setDescription("Annual checkup");
+
+		Visit visit2 = new Visit();
+		visit2.setId(2);
+		visit2.setDate(LocalDate.of(2023, 2, 15));
+		visit2.setDescription("Rabies vaccination");
+
+		List<Visit> visits = Arrays.asList(visit1, visit2);
+		given(this.visitRepository.findAll()).willReturn(visits);
+
+		// when
+		mockMvc.perform(get("/api/visits"))
+			// then
+			.andExpect(status().isOk())
+			.andExpect(content().contentType(MediaType.APPLICATION_JSON))
+			.andExpect(jsonPath("$", hasSize(2)))
+			.andExpect(jsonPath("$[0].id", is(1)))
+			.andExpect(jsonPath("$[0].date", is("2023-01-01")))
+			.andExpect(jsonPath("$[0].description", is("Annual checkup")))
+			.andExpect(jsonPath("$[1].id", is(2)))
+			.andExpect(jsonPath("$[1].date", is("2023-02-15")))
+			.andExpect(jsonPath("$[1].description", is("Rabies vaccination")));
+	}
+
+	@Test
+	void testGetVisit() throws Exception {
+		// given
+		Visit visit = new Visit();
+		visit.setId(1);
+		visit.setDate(LocalDate.of(2023, 1, 1));
+		visit.setDescription("Annual checkup");
+
+		given(this.visitRepository.findById(1)).willReturn(Optional.of(visit));
+
+		// when
+		mockMvc.perform(get("/api/visits/1"))
+			// then
+			.andExpect(status().isOk())
+			.andExpect(content().contentType(MediaType.APPLICATION_JSON))
+			.andExpect(jsonPath("$.id", is(1)))
+			.andExpect(jsonPath("$.date", is("2023-01-01")))
+			.andExpect(jsonPath("$.description", is("Annual checkup")));
+	}
+
+	@Test
+	void testGetVisitNotFound() throws Exception {
+		// given
+		given(this.visitRepository.findById(999)).willReturn(Optional.empty());
+
+		// when
+		mockMvc.perform(get("/api/visits/999"))
+			// then
+			.andExpect(status().isNotFound());
+	}
+
+	@Test
+	void testGetVisitsByPet() throws Exception {
+		// given
+		Visit visit1 = new Visit();
+		visit1.setId(1);
+		visit1.setDate(LocalDate.of(2023, 1, 1));
+		visit1.setDescription("Annual checkup");
+
+		Visit visit2 = new Visit();
+		visit2.setId(2);
+		visit2.setDate(LocalDate.of(2023, 2, 15));
+		visit2.setDescription("Rabies vaccination");
+
+		List<Visit> visits = Arrays.asList(visit1, visit2);
+		given(this.petRepository.existsById(1)).willReturn(true);
+		given(this.visitRepository.findByPetId(1)).willReturn(visits);
+
+		// when
+		mockMvc.perform(get("/api/pets/1/visits"))
+			// then
+			.andExpect(status().isOk())
+			.andExpect(content().contentType(MediaType.APPLICATION_JSON))
+			.andExpect(jsonPath("$", hasSize(2)))
+			.andExpect(jsonPath("$[0].id", is(1)))
+			.andExpect(jsonPath("$[0].date", is("2023-01-01")))
+			.andExpect(jsonPath("$[0].description", is("Annual checkup")))
+			.andExpect(jsonPath("$[1].id", is(2)))
+			.andExpect(jsonPath("$[1].date", is("2023-02-15")))
+			.andExpect(jsonPath("$[1].description", is("Rabies vaccination")));
+	}
+
+	@Test
+	void testGetVisitsByPetNotFound() throws Exception {
+		// given
+		given(this.petRepository.existsById(999)).willReturn(false);
+
+		// when
+		mockMvc.perform(get("/api/pets/999/visits"))
+			// then
+			.andExpect(status().isNotFound());
+	}
+
+	@Test
+	void testAddVisit() throws Exception {
+		// given
+		Pet pet = new Pet();
+		pet.setId(1);
+		pet.setName("Leo");
+
+		Visit newVisit = new Visit();
+		newVisit.setDate(LocalDate.of(2023, 3, 10));
+		newVisit.setDescription("Dental cleaning");
+
+		given(this.petRepository.findById(1)).willReturn(Optional.of(pet));
+		given(this.petRepository.save(any(Pet.class))).willAnswer(invocation -> {
+			Pet savedPet = invocation.getArgument(0);
+			Visit savedVisit = savedPet.getVisits().iterator().next();
+			savedVisit.setId(5);
+			return savedPet;
+		});
+
+		// when
+		mockMvc
+			.perform(post("/api/pets/1/visits").contentType(MediaType.APPLICATION_JSON)
+				.content("{\"date\":\"2023-03-10\",\"description\":\"Dental cleaning\"}"))
+			// then
+			.andExpect(status().isCreated())
+			.andExpect(header().string("Location", containsString("/api/pets/1/visits/5")))
+			.andExpect(jsonPath("$.date", is("2023-03-10")))
+			.andExpect(jsonPath("$.description", is("Dental cleaning")));
+
+		verify(this.petRepository).save(any(Pet.class));
+	}
+
+	@Test
+	void testAddVisitPetNotFound() throws Exception {
+		// given
+		given(this.petRepository.findById(999)).willReturn(Optional.empty());
+
+		// when
+		mockMvc
+			.perform(post("/api/pets/999/visits").contentType(MediaType.APPLICATION_JSON)
+				.content("{\"date\":\"2023-03-10\",\"description\":\"Dental cleaning\"}"))
+			// then
+			.andExpect(status().isNotFound());
+
+		verify(this.petRepository, never()).save(any(Pet.class));
+	}
+
+	@Test
+	void testAddVisitInvalidDescription() throws Exception {
+		// given
+		Pet pet = new Pet();
+		pet.setId(1);
+		pet.setName("Leo");
+
+		given(this.petRepository.findById(1)).willReturn(Optional.of(pet));
+
+		// when
+		mockMvc
+			.perform(post("/api/pets/1/visits").contentType(MediaType.APPLICATION_JSON)
+				.content("{\"date\":\"2023-03-10\",\"description\":\"\"}"))
+			// then
+			.andExpect(status().isBadRequest());
+
+		verify(this.petRepository, never()).save(any(Pet.class));
+	}
+
+	@Test
+	void testUpdateVisit() throws Exception {
+		// given
+		Visit visit = new Visit();
+		visit.setId(1);
+		visit.setDate(LocalDate.of(2023, 1, 1));
+		visit.setDescription("Annual checkup");
+
+		given(this.visitRepository.findById(1)).willReturn(Optional.of(visit));
+		given(this.visitRepository.save(any(Visit.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+		// when
+		mockMvc
+			.perform(put("/api/visits/1").contentType(MediaType.APPLICATION_JSON)
+				.content("{\"date\":\"2023-01-02\",\"description\":\"Annual checkup updated\"}"))
+			// then
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.id", is(1)))
+			.andExpect(jsonPath("$.date", is("2023-01-02")))
+			.andExpect(jsonPath("$.description", is("Annual checkup updated")));
+
+		verify(this.visitRepository).save(any(Visit.class));
+	}
+
+	@Test
+	void testUpdateVisitNotFound() throws Exception {
+		// given
+		given(this.visitRepository.findById(999)).willReturn(Optional.empty());
+
+		// when
+		mockMvc
+			.perform(put("/api/visits/999").contentType(MediaType.APPLICATION_JSON)
+				.content("{\"date\":\"2023-01-02\",\"description\":\"Annual checkup updated\"}"))
+			// then
+			.andExpect(status().isNotFound());
+
+		verify(this.visitRepository, never()).save(any(Visit.class));
+	}
+
+	@Test
+	void testDeleteVisit() throws Exception {
+		// given
+		given(this.visitRepository.existsById(1)).willReturn(true);
+
+		// when
+		mockMvc.perform(delete("/api/visits/1"))
+			// then
+			.andExpect(status().isNoContent());
+
+		verify(this.visitRepository).deleteById(1);
+	}
+
+	@Test
+	void testDeleteVisitNotFound() throws Exception {
+		// given
+		given(this.visitRepository.existsById(999)).willReturn(false);
+
+		// when
+		mockMvc.perform(delete("/api/visits/999"))
+			// then
+			.andExpect(status().isNotFound());
+
+		verify(this.visitRepository, never()).deleteById(anyInt());
+	}
+
+}


### PR DESCRIPTION
Create REST controllers for managing owners, pets, and visits in the application. Ensure that each controller provides endpoints for standard CRUD operations. Implement the necessary repository interfaces to interact with the database. Include validation for inputs and handle appropriate HTTP responses for success and error cases. Additionally, write a series of test cases to validate the functionality of these endpoints and ensure they work as expected.

FAIL_TO_PASS: org.springframework.samples.petclinic.owner.OwnerRestControllerTests, org.springframework.samples.petclinic.owner.PetRestControllerTests, org.springframework.samples.petclinic.owner.VisitRestControllerTests