### PR TITLE
Implement API versioning for the owner and pet controllers #32

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/owner/OwnerRestController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/OwnerRestController.java
@@ -41,7 +41,7 @@ import jakarta.validation.Valid;
  * @author Junie
  */
 @RestController
-@RequestMapping("/api/owners")
+@RequestMapping("/api/v1/owners")
 public class OwnerRestController {
 
 	private final OwnerRepository ownerRepository;

--- a/src/main/java/org/springframework/samples/petclinic/owner/PetRestController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/PetRestController.java
@@ -43,7 +43,7 @@ import jakarta.validation.Valid;
  * @author Junie
  */
 @RestController
-@RequestMapping("/api")
+@RequestMapping("/api/v1")
 public class PetRestController {
 
 	private final PetRepository petRepository;

--- a/src/main/java/org/springframework/samples/petclinic/owner/VisitRestController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/VisitRestController.java
@@ -42,7 +42,7 @@ import jakarta.validation.Valid;
  * @author Junie
  */
 @RestController
-@RequestMapping("/api")
+@RequestMapping("/api/v1")
 public class VisitRestController {
 
 	private final VisitRepository visitRepository;

--- a/src/test/java/org/springframework/samples/petclinic/owner/OwnerRestControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/owner/OwnerRestControllerTests.java
@@ -84,7 +84,7 @@ class OwnerRestControllerTests {
 		given(this.ownerRepository.findAll(any(Pageable.class))).willReturn(ownersPage);
 
 		// when
-		mockMvc.perform(get("/api/owners"))
+		mockMvc.perform(get("/api/v1/owners"))
 			// then
 			.andExpect(status().isOk())
 			.andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -114,7 +114,7 @@ class OwnerRestControllerTests {
 		given(this.ownerRepository.findByLastNameStartingWith(eq("Davis"), any(Pageable.class))).willReturn(ownersPage);
 
 		// when
-		mockMvc.perform(get("/api/owners?lastName=Davis"))
+		mockMvc.perform(get("/api/v1/owners?lastName=Davis"))
 			// then
 			.andExpect(status().isOk())
 			.andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -138,7 +138,7 @@ class OwnerRestControllerTests {
 		given(this.ownerRepository.findById(1)).willReturn(Optional.of(owner));
 
 		// when
-		mockMvc.perform(get("/api/owners/1"))
+		mockMvc.perform(get("/api/v1/owners/1"))
 			// then
 			.andExpect(status().isOk())
 			.andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -156,7 +156,7 @@ class OwnerRestControllerTests {
 		given(this.ownerRepository.findById(999)).willReturn(Optional.empty());
 
 		// when
-		mockMvc.perform(get("/api/owners/999"))
+		mockMvc.perform(get("/api/v1/owners/999"))
 			// then
 			.andExpect(status().isNotFound());
 	}
@@ -178,12 +178,12 @@ class OwnerRestControllerTests {
 		});
 
 		// when
-		mockMvc.perform(post("/api/owners").contentType(MediaType.APPLICATION_JSON)
+		mockMvc.perform(post("/api/v1/owners").contentType(MediaType.APPLICATION_JSON)
 			.content(
 					"{\"firstName\":\"John\",\"lastName\":\"Doe\",\"address\":\"123 Main St\",\"city\":\"Anytown\",\"telephone\":\"1234567890\"}"))
 			// then
 			.andExpect(status().isCreated())
-			.andExpect(header().string("Location", containsString("/api/owners/10")))
+			.andExpect(header().string("Location", containsString("/api/v1/owners/10")))
 			.andExpect(jsonPath("$.id", is(10)))
 			.andExpect(jsonPath("$.firstName", is("John")))
 			.andExpect(jsonPath("$.lastName", is("Doe")))
@@ -197,7 +197,7 @@ class OwnerRestControllerTests {
 	@Test
 	void testCreateOwnerWithId() throws Exception {
 		// when
-		mockMvc.perform(post("/api/owners").contentType(MediaType.APPLICATION_JSON)
+		mockMvc.perform(post("/api/v1/owners").contentType(MediaType.APPLICATION_JSON)
 			.content(
 					"{\"id\":1,\"firstName\":\"John\",\"lastName\":\"Doe\",\"address\":\"123 Main St\",\"city\":\"Anytown\",\"telephone\":\"1234567890\"}"))
 			// then
@@ -209,7 +209,8 @@ class OwnerRestControllerTests {
 	@Test
 	void testCreateOwnerInvalidData() throws Exception {
 		// when - missing required fields
-		mockMvc.perform(post("/api/owners").contentType(MediaType.APPLICATION_JSON).content("{\"firstName\":\"John\"}"))
+		mockMvc
+			.perform(post("/api/v1/owners").contentType(MediaType.APPLICATION_JSON).content("{\"firstName\":\"John\"}"))
 			// then
 			.andExpect(status().isBadRequest());
 
@@ -231,7 +232,7 @@ class OwnerRestControllerTests {
 		given(this.ownerRepository.save(any(Owner.class))).willAnswer(invocation -> invocation.getArgument(0));
 
 		// when
-		mockMvc.perform(put("/api/owners/1").contentType(MediaType.APPLICATION_JSON)
+		mockMvc.perform(put("/api/v1/owners/1").contentType(MediaType.APPLICATION_JSON)
 			.content(
 					"{\"firstName\":\"George Updated\",\"lastName\":\"Franklin\",\"address\":\"110 W. Liberty St.\",\"city\":\"Madison\",\"telephone\":\"6085551023\"}"))
 			// then
@@ -252,7 +253,7 @@ class OwnerRestControllerTests {
 		given(this.ownerRepository.findById(999)).willReturn(Optional.empty());
 
 		// when
-		mockMvc.perform(put("/api/owners/999").contentType(MediaType.APPLICATION_JSON)
+		mockMvc.perform(put("/api/v1/owners/999").contentType(MediaType.APPLICATION_JSON)
 			.content(
 					"{\"firstName\":\"George Updated\",\"lastName\":\"Franklin\",\"address\":\"110 W. Liberty St.\",\"city\":\"Madison\",\"telephone\":\"6085551023\"}"))
 			// then
@@ -275,7 +276,7 @@ class OwnerRestControllerTests {
 		given(this.ownerRepository.findById(1)).willReturn(Optional.of(existingOwner));
 
 		// when
-		mockMvc.perform(put("/api/owners/1").contentType(MediaType.APPLICATION_JSON)
+		mockMvc.perform(put("/api/v1/owners/1").contentType(MediaType.APPLICATION_JSON)
 			.content(
 					"{\"id\":2,\"firstName\":\"George Updated\",\"lastName\":\"Franklin\",\"address\":\"110 W. Liberty St.\",\"city\":\"Madison\",\"telephone\":\"6085551023\"}"))
 			// then
@@ -290,7 +291,7 @@ class OwnerRestControllerTests {
 		given(this.ownerRepository.existsById(1)).willReturn(true);
 
 		// when
-		mockMvc.perform(delete("/api/owners/1"))
+		mockMvc.perform(delete("/api/v1/owners/1"))
 			// then
 			.andExpect(status().isNoContent());
 
@@ -303,7 +304,7 @@ class OwnerRestControllerTests {
 		given(this.ownerRepository.existsById(999)).willReturn(false);
 
 		// when
-		mockMvc.perform(delete("/api/owners/999"))
+		mockMvc.perform(delete("/api/v1/owners/999"))
 			// then
 			.andExpect(status().isNotFound());
 

--- a/src/test/java/org/springframework/samples/petclinic/owner/PetRestControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/owner/PetRestControllerTests.java
@@ -91,7 +91,7 @@ class PetRestControllerTests {
 		given(this.petRepository.findAll(any(Pageable.class))).willReturn(petsPage);
 
 		// when
-		mockMvc.perform(get("/api/pets"))
+		mockMvc.perform(get("/api/v1/pets"))
 			// then
 			.andExpect(status().isOk())
 			.andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -105,7 +105,7 @@ class PetRestControllerTests {
 			.andExpect(jsonPath("$.totalElements", is(2)));
 
 		// Test with custom page and size parameters
-		mockMvc.perform(get("/api/pets?page=2&size=5"))
+		mockMvc.perform(get("/api/v1/pets?page=2&size=5"))
 			.andExpect(status().isOk())
 			.andExpect(content().contentType(MediaType.APPLICATION_JSON))
 			.andExpect(jsonPath("$.content", hasSize(2)));
@@ -129,7 +129,7 @@ class PetRestControllerTests {
 		given(this.petRepository.findById(1)).willReturn(Optional.of(pet));
 
 		// when
-		mockMvc.perform(get("/api/pets/1"))
+		mockMvc.perform(get("/api/v1/pets/1"))
 			// then
 			.andExpect(status().isOk())
 			.andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -146,7 +146,7 @@ class PetRestControllerTests {
 		given(this.petRepository.findById(999)).willReturn(Optional.empty());
 
 		// when
-		mockMvc.perform(get("/api/pets/999"))
+		mockMvc.perform(get("/api/v1/pets/999"))
 			// then
 			.andExpect(status().isNotFound());
 	}
@@ -176,7 +176,7 @@ class PetRestControllerTests {
 		given(this.petRepository.findByOwnerId(eq(1), any(Pageable.class))).willReturn(petsPage);
 
 		// when
-		mockMvc.perform(get("/api/owners/1/pets"))
+		mockMvc.perform(get("/api/v1/owners/1/pets"))
 			// then
 			.andExpect(status().isOk())
 			.andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -190,7 +190,7 @@ class PetRestControllerTests {
 			.andExpect(jsonPath("$.totalElements", is(2)));
 
 		// Test with custom page and size parameters
-		mockMvc.perform(get("/api/owners/1/pets?page=2&size=5"))
+		mockMvc.perform(get("/api/v1/owners/1/pets?page=2&size=5"))
 			.andExpect(status().isOk())
 			.andExpect(content().contentType(MediaType.APPLICATION_JSON))
 			.andExpect(jsonPath("$.content", hasSize(2)));
@@ -204,7 +204,7 @@ class PetRestControllerTests {
 		given(this.ownerRepository.existsById(999)).willReturn(false);
 
 		// when
-		mockMvc.perform(get("/api/owners/999/pets"))
+		mockMvc.perform(get("/api/v1/owners/999/pets"))
 			// then
 			.andExpect(status().isNotFound());
 	}
@@ -236,11 +236,11 @@ class PetRestControllerTests {
 
 		// when
 		mockMvc
-			.perform(post("/api/owners/1/pets").contentType(MediaType.APPLICATION_JSON)
+			.perform(post("/api/v1/owners/1/pets").contentType(MediaType.APPLICATION_JSON)
 				.content("{\"name\":\"Leo\",\"birthDate\":\"2020-09-07\",\"type\":{\"id\":1}}"))
 			// then
 			.andExpect(status().isCreated())
-			.andExpect(header().string("Location", containsString("/api/owners/1/pets/1")))
+			.andExpect(header().string("Location", containsString("/api/v1/owners/1/pets/1")))
 			.andExpect(jsonPath("$.name", is("Leo")))
 			.andExpect(jsonPath("$.birthDate", is("2020-09-07")))
 			.andExpect(jsonPath("$.type.id", is(1)));
@@ -255,7 +255,7 @@ class PetRestControllerTests {
 
 		// when
 		mockMvc
-			.perform(post("/api/owners/999/pets").contentType(MediaType.APPLICATION_JSON)
+			.perform(post("/api/v1/owners/999/pets").contentType(MediaType.APPLICATION_JSON)
 				.content("{\"name\":\"Leo\",\"birthDate\":\"2020-09-07\",\"type\":{\"id\":1}}"))
 			// then
 			.andExpect(status().isNotFound());
@@ -275,7 +275,7 @@ class PetRestControllerTests {
 
 		// when
 		mockMvc
-			.perform(post("/api/owners/1/pets").contentType(MediaType.APPLICATION_JSON)
+			.perform(post("/api/v1/owners/1/pets").contentType(MediaType.APPLICATION_JSON)
 				.content("{\"name\":\"\",\"birthDate\":\"2020-09-07\",\"type\":{\"id\":1}}"))
 			// then
 			.andExpect(status().isBadRequest());
@@ -311,7 +311,7 @@ class PetRestControllerTests {
 
 		// when
 		mockMvc
-			.perform(post("/api/owners/1/pets").contentType(MediaType.APPLICATION_JSON)
+			.perform(post("/api/v1/owners/1/pets").contentType(MediaType.APPLICATION_JSON)
 				.content("{\"name\":\"Leo\",\"birthDate\":\"2020-09-07\",\"type\":{\"id\":1}}"))
 			// then
 			.andExpect(status().isConflict());
@@ -366,7 +366,7 @@ class PetRestControllerTests {
 
 		// when
 		mockMvc
-			.perform(put("/api/pets/1").contentType(MediaType.APPLICATION_JSON)
+			.perform(put("/api/v1/pets/1").contentType(MediaType.APPLICATION_JSON)
 				.content("{\"name\":\"Leo Updated\",\"birthDate\":\"2020-09-07\",\"type\":{\"id\":1}}"))
 			// then
 			.andExpect(status().isOk())
@@ -385,7 +385,7 @@ class PetRestControllerTests {
 
 		// when
 		mockMvc
-			.perform(put("/api/pets/999").contentType(MediaType.APPLICATION_JSON)
+			.perform(put("/api/v1/pets/999").contentType(MediaType.APPLICATION_JSON)
 				.content("{\"name\":\"Leo Updated\",\"birthDate\":\"2020-09-07\",\"type\":{\"id\":1}}"))
 			// then
 			.andExpect(status().isNotFound());
@@ -444,7 +444,7 @@ class PetRestControllerTests {
 
 		// when
 		mockMvc
-			.perform(put("/api/pets/1").contentType(MediaType.APPLICATION_JSON)
+			.perform(put("/api/v1/pets/1").contentType(MediaType.APPLICATION_JSON)
 				.content("{\"name\":\"Basil\",\"birthDate\":\"2020-09-07\",\"type\":{\"id\":1}}"))
 			// then
 			.andExpect(status().isConflict());
@@ -495,7 +495,7 @@ class PetRestControllerTests {
 		given(this.ownerRepository.save(any(Owner.class))).willReturn(owner);
 
 		// when
-		mockMvc.perform(delete("/api/pets/1"))
+		mockMvc.perform(delete("/api/v1/pets/1"))
 			// then
 			.andExpect(status().isNoContent());
 
@@ -509,7 +509,7 @@ class PetRestControllerTests {
 		given(this.petRepository.existsById(999)).willReturn(false);
 
 		// when
-		mockMvc.perform(delete("/api/pets/999"))
+		mockMvc.perform(delete("/api/v1/pets/999"))
 			// then
 			.andExpect(status().isNotFound());
 

--- a/src/test/java/org/springframework/samples/petclinic/owner/VisitRestControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/owner/VisitRestControllerTests.java
@@ -80,7 +80,7 @@ class VisitRestControllerTests {
 		given(this.visitRepository.findAll(any(Pageable.class))).willReturn(visitsPage);
 
 		// when
-		mockMvc.perform(get("/api/visits"))
+		mockMvc.perform(get("/api/v1/visits"))
 			// then
 			.andExpect(status().isOk())
 			.andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -96,7 +96,7 @@ class VisitRestControllerTests {
 			.andExpect(jsonPath("$.totalElements", is(2)));
 
 		// Test with custom page and size parameters
-		mockMvc.perform(get("/api/visits?page=2&size=5"))
+		mockMvc.perform(get("/api/v1/visits?page=2&size=5"))
 			.andExpect(status().isOk())
 			.andExpect(content().contentType(MediaType.APPLICATION_JSON))
 			.andExpect(jsonPath("$.content", hasSize(2)));
@@ -115,7 +115,7 @@ class VisitRestControllerTests {
 		given(this.visitRepository.findById(1)).willReturn(Optional.of(visit));
 
 		// when
-		mockMvc.perform(get("/api/visits/1"))
+		mockMvc.perform(get("/api/v1/visits/1"))
 			// then
 			.andExpect(status().isOk())
 			.andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -130,7 +130,7 @@ class VisitRestControllerTests {
 		given(this.visitRepository.findById(999)).willReturn(Optional.empty());
 
 		// when
-		mockMvc.perform(get("/api/visits/999"))
+		mockMvc.perform(get("/api/v1/visits/999"))
 			// then
 			.andExpect(status().isNotFound());
 	}
@@ -154,7 +154,7 @@ class VisitRestControllerTests {
 		given(this.visitRepository.findByPetId(eq(1), any(Pageable.class))).willReturn(visitsPage);
 
 		// when
-		mockMvc.perform(get("/api/pets/1/visits"))
+		mockMvc.perform(get("/api/v1/pets/1/visits"))
 			// then
 			.andExpect(status().isOk())
 			.andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -170,7 +170,7 @@ class VisitRestControllerTests {
 			.andExpect(jsonPath("$.totalElements", is(2)));
 
 		// Test with custom page and size parameters
-		mockMvc.perform(get("/api/pets/1/visits?page=2&size=5"))
+		mockMvc.perform(get("/api/v1/pets/1/visits?page=2&size=5"))
 			.andExpect(status().isOk())
 			.andExpect(content().contentType(MediaType.APPLICATION_JSON))
 			.andExpect(jsonPath("$.content", hasSize(2)));
@@ -184,7 +184,7 @@ class VisitRestControllerTests {
 		given(this.petRepository.existsById(999)).willReturn(false);
 
 		// when
-		mockMvc.perform(get("/api/pets/999/visits"))
+		mockMvc.perform(get("/api/v1/pets/999/visits"))
 			// then
 			.andExpect(status().isNotFound());
 	}
@@ -210,11 +210,11 @@ class VisitRestControllerTests {
 
 		// when
 		mockMvc
-			.perform(post("/api/pets/1/visits").contentType(MediaType.APPLICATION_JSON)
+			.perform(post("/api/v1/pets/1/visits").contentType(MediaType.APPLICATION_JSON)
 				.content("{\"date\":\"2023-03-10\",\"description\":\"Dental cleaning\"}"))
 			// then
 			.andExpect(status().isCreated())
-			.andExpect(header().string("Location", containsString("/api/pets/1/visits/5")))
+			.andExpect(header().string("Location", containsString("/api/v1/pets/1/visits/5")))
 			.andExpect(jsonPath("$.date", is("2023-03-10")))
 			.andExpect(jsonPath("$.description", is("Dental cleaning")));
 
@@ -228,7 +228,7 @@ class VisitRestControllerTests {
 
 		// when
 		mockMvc
-			.perform(post("/api/pets/999/visits").contentType(MediaType.APPLICATION_JSON)
+			.perform(post("/api/v1/pets/999/visits").contentType(MediaType.APPLICATION_JSON)
 				.content("{\"date\":\"2023-03-10\",\"description\":\"Dental cleaning\"}"))
 			// then
 			.andExpect(status().isNotFound());
@@ -247,7 +247,7 @@ class VisitRestControllerTests {
 
 		// when
 		mockMvc
-			.perform(post("/api/pets/1/visits").contentType(MediaType.APPLICATION_JSON)
+			.perform(post("/api/v1/pets/1/visits").contentType(MediaType.APPLICATION_JSON)
 				.content("{\"date\":\"2023-03-10\",\"description\":\"\"}"))
 			// then
 			.andExpect(status().isBadRequest());
@@ -268,7 +268,7 @@ class VisitRestControllerTests {
 
 		// when
 		mockMvc
-			.perform(put("/api/visits/1").contentType(MediaType.APPLICATION_JSON)
+			.perform(put("/api/v1/visits/1").contentType(MediaType.APPLICATION_JSON)
 				.content("{\"date\":\"2023-01-02\",\"description\":\"Annual checkup updated\"}"))
 			// then
 			.andExpect(status().isOk())
@@ -286,7 +286,7 @@ class VisitRestControllerTests {
 
 		// when
 		mockMvc
-			.perform(put("/api/visits/999").contentType(MediaType.APPLICATION_JSON)
+			.perform(put("/api/v1/visits/999").contentType(MediaType.APPLICATION_JSON)
 				.content("{\"date\":\"2023-01-02\",\"description\":\"Annual checkup updated\"}"))
 			// then
 			.andExpect(status().isNotFound());
@@ -300,7 +300,7 @@ class VisitRestControllerTests {
 		given(this.visitRepository.existsById(1)).willReturn(true);
 
 		// when
-		mockMvc.perform(delete("/api/visits/1"))
+		mockMvc.perform(delete("/api/v1/visits/1"))
 			// then
 			.andExpect(status().isNoContent());
 
@@ -313,7 +313,7 @@ class VisitRestControllerTests {
 		given(this.visitRepository.existsById(999)).willReturn(false);
 
 		// when
-		mockMvc.perform(delete("/api/visits/999"))
+		mockMvc.perform(delete("/api/v1/visits/999"))
 			// then
 			.andExpect(status().isNotFound());
 


### PR DESCRIPTION
Implement API versioning for the owner and pet controllers by updating the request mapping prefixes to include a version number in the URL. Ensure that the changes are consistent across all relevant controllers, making it easier to manage future updates and changes to the API.

FAIL_TO_PASS: org.springframework.samples.petclinic.owner.OwnerRestControllerTests, org.springframework.samples.petclinic.owner.PetRestControllerTests, org.springframework.samples.petclinic.owner.VisitRestControllerTests