### PR TITLE
Add email field to Owner #36

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/owner/Owner.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/Owner.java
@@ -30,6 +30,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OrderBy;
 import jakarta.persistence.Table;
+import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.NotBlank;
 
@@ -60,6 +61,11 @@ public class Owner extends Person {
 	@Pattern(regexp = "\\d{10}", message = "{telephone.invalid}")
 	private String telephone;
 
+	@Column(name = "email")
+	@NotBlank
+	@Email
+	private String email;
+
 	@OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER)
 	@JoinColumn(name = "owner_id")
 	@OrderBy("name")
@@ -87,6 +93,14 @@ public class Owner extends Person {
 
 	public void setTelephone(String telephone) {
 		this.telephone = telephone;
+	}
+
+	public String getEmail() {
+		return this.email;
+	}
+
+	public void setEmail(String email) {
+		this.email = email;
 	}
 
 	public List<Pet> getPets() {
@@ -152,6 +166,7 @@ public class Owner extends Person {
 			.append("address", this.address)
 			.append("city", this.city)
 			.append("telephone", this.telephone)
+			.append("email", this.email)
 			.toString();
 	}
 

--- a/src/main/resources/db/h2/schema.sql
+++ b/src/main/resources/db/h2/schema.sql
@@ -39,7 +39,8 @@ CREATE TABLE owners (
   last_name  VARCHAR_IGNORECASE(30),
   address    VARCHAR(255),
   city       VARCHAR(80),
-  telephone  VARCHAR(20)
+  telephone  VARCHAR(20),
+  email      VARCHAR(255)
 );
 CREATE INDEX owners_last_name ON owners (last_name);
 

--- a/src/main/resources/db/hsqldb/schema.sql
+++ b/src/main/resources/db/hsqldb/schema.sql
@@ -39,7 +39,8 @@ CREATE TABLE owners (
   last_name  VARCHAR_IGNORECASE(30),
   address    VARCHAR(255),
   city       VARCHAR(80),
-  telephone  VARCHAR(20)
+  telephone  VARCHAR(20),
+  email      VARCHAR(255)
 );
 CREATE INDEX owners_last_name ON owners (last_name);
 

--- a/src/main/resources/db/mysql/schema.sql
+++ b/src/main/resources/db/mysql/schema.sql
@@ -32,6 +32,7 @@ CREATE TABLE IF NOT EXISTS owners (
   address VARCHAR(255),
   city VARCHAR(80),
   telephone VARCHAR(20),
+  email VARCHAR(255),
   INDEX(last_name)
 ) engine=InnoDB;
 

--- a/src/main/resources/db/postgres/schema.sql
+++ b/src/main/resources/db/postgres/schema.sql
@@ -29,7 +29,8 @@ CREATE TABLE IF NOT EXISTS owners (
   last_name  TEXT,
   address    TEXT,
   city       TEXT,
-  telephone  TEXT
+  telephone  TEXT,
+  email      TEXT
 );
 CREATE INDEX ON owners (last_name);
 

--- a/src/main/resources/templates/owners/createOrUpdateOwnerForm.html
+++ b/src/main/resources/templates/owners/createOrUpdateOwnerForm.html
@@ -12,6 +12,7 @@
       <input th:replace="~{fragments/inputField :: input (#{address}, 'address', 'text')}" />
       <input th:replace="~{fragments/inputField :: input (#{city}, 'city', 'text')}" />
       <input th:replace="~{fragments/inputField :: input (#{telephone}, 'telephone', 'text')}" />
+      <input th:replace="~{fragments/inputField :: input ('Email', 'email', 'email')}" />
     </div>
     <div class="form-group">
       <div class="col-sm-offset-2 col-sm-10">

--- a/src/main/resources/templates/owners/ownerDetails.html
+++ b/src/main/resources/templates/owners/ownerDetails.html
@@ -31,6 +31,10 @@
       <th th:text="#{telephone}">Telephone</th>
       <td th:text="*{telephone}"></td>
     </tr>
+    <tr>
+      <th>Email</th>
+      <td th:text="*{email}"></td>
+    </tr>
   </table>
 
   <a th:href="@{__${owner.id}__/edit}" class="btn btn-primary" th:text="#{editOwner}">Edit

--- a/src/main/resources/templates/owners/ownersList.html
+++ b/src/main/resources/templates/owners/ownersList.html
@@ -13,17 +13,19 @@
         <th th:text="#{address}" style="width: 200px;">Address</th>
         <th th:text="#{city}">City</th>
         <th th:text="#{telephone}" style="width: 120px">Telephone</th>
+        <th>Email</th>
         <th th:text="#{pets}">Pets</th>
       </tr>
     </thead>
     <tbody>
       <tr th:each="owner : ${listOwners}">
         <td>
-          <a th:href="@{/owners/__${owner.id}__}" th:text="${owner.firstName + ' ' + owner.lastName}" /></a>
+          <a th:href="@{/owners/__${owner.id}__}" th:text="${owner.firstName + ' ' + owner.lastName}"></a>
         </td>
         <td th:text="${owner.address}" />
         <td th:text="${owner.city}" />
         <td th:text="${owner.telephone}" />
+        <td th:text="${owner.email}" />
         <td><span th:text="${#strings.listJoin(owner.pets, ', ')}" /></td>
       </tr>
     </tbody>

--- a/src/test/java/org/springframework/samples/petclinic/model/ValidatorTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/model/ValidatorTests.java
@@ -23,6 +23,7 @@ import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.context.i18n.LocaleContextHolder;
+import org.springframework.samples.petclinic.owner.Owner;
 import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
 
 import jakarta.validation.ConstraintViolation;
@@ -55,6 +56,43 @@ class ValidatorTests {
 		ConstraintViolation<Person> violation = constraintViolations.iterator().next();
 		assertThat(violation.getPropertyPath()).hasToString("firstName");
 		assertThat(violation.getMessage()).isEqualTo("must not be blank");
+	}
+
+	@Test
+	void shouldValidateWhenEmailFormatIsValid() {
+		LocaleContextHolder.setLocale(Locale.ENGLISH);
+		Owner owner = new Owner();
+		owner.setFirstName("John");
+		owner.setLastName("Doe");
+		owner.setAddress("123 Main St");
+		owner.setCity("New York");
+		owner.setTelephone("1234567890");
+		owner.setEmail("john.doe@example.com");
+
+		Validator validator = createValidator();
+		Set<ConstraintViolation<Owner>> constraintViolations = validator.validate(owner);
+
+		assertThat(constraintViolations).isEmpty();
+	}
+
+	@Test
+	void shouldNotValidateWhenEmailFormatIsInvalid() {
+		LocaleContextHolder.setLocale(Locale.ENGLISH);
+		Owner owner = new Owner();
+		owner.setFirstName("John");
+		owner.setLastName("Doe");
+		owner.setAddress("123 Main St");
+		owner.setCity("New York");
+		owner.setTelephone("1234567890");
+		owner.setEmail("invalid-email");
+
+		Validator validator = createValidator();
+		Set<ConstraintViolation<Owner>> constraintViolations = validator.validate(owner);
+
+		assertThat(constraintViolations).hasSize(1);
+		ConstraintViolation<Owner> violation = constraintViolations.iterator().next();
+		assertThat(violation.getPropertyPath()).hasToString("email");
+		assertThat(violation.getMessage()).isEqualTo("must be a well-formed email address");
 	}
 
 }

--- a/src/test/java/org/springframework/samples/petclinic/owner/OwnerControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/owner/OwnerControllerTests.java
@@ -76,6 +76,7 @@ class OwnerControllerTests {
 		george.setAddress("110 W. Liberty St.");
 		george.setCity("Madison");
 		george.setTelephone("6085551023");
+		george.setEmail("george.franklin@example.com");
 		Pet max = new Pet();
 		PetType dog = new PetType();
 		dog.setName("dog");
@@ -116,7 +117,8 @@ class OwnerControllerTests {
 				.param("lastName", "Bloggs")
 				.param("address", "123 Caramel Street")
 				.param("city", "London")
-				.param("telephone", "1316761638"))
+				.param("telephone", "1316761638")
+				.param("email", "joe.bloggs@example.com"))
 			.andExpect(status().is3xxRedirection());
 	}
 
@@ -177,6 +179,7 @@ class OwnerControllerTests {
 			.andExpect(model().attribute("owner", hasProperty("address", is("110 W. Liberty St."))))
 			.andExpect(model().attribute("owner", hasProperty("city", is("Madison"))))
 			.andExpect(model().attribute("owner", hasProperty("telephone", is("6085551023"))))
+			.andExpect(model().attribute("owner", hasProperty("email", is("george.franklin@example.com"))))
 			.andExpect(view().name("owners/createOrUpdateOwnerForm"));
 	}
 
@@ -187,7 +190,8 @@ class OwnerControllerTests {
 				.param("lastName", "Bloggs")
 				.param("address", "123 Caramel Street")
 				.param("city", "London")
-				.param("telephone", "1616291589"))
+				.param("telephone", "1616291589")
+				.param("email", "joe.bloggs@example.com"))
 			.andExpect(status().is3xxRedirection())
 			.andExpect(view().name("redirect:/owners/{ownerId}"));
 	}
@@ -222,6 +226,7 @@ class OwnerControllerTests {
 			.andExpect(model().attribute("owner", hasProperty("address", is("110 W. Liberty St."))))
 			.andExpect(model().attribute("owner", hasProperty("city", is("Madison"))))
 			.andExpect(model().attribute("owner", hasProperty("telephone", is("6085551023"))))
+			.andExpect(model().attribute("owner", hasProperty("email", is("george.franklin@example.com"))))
 			.andExpect(model().attribute("owner", hasProperty("pets", not(empty()))))
 			.andExpect(model().attribute("owner",
 					hasProperty("pets", hasItem(hasProperty("visits", hasSize(greaterThan(0)))))))
@@ -239,6 +244,7 @@ class OwnerControllerTests {
 		owner.setAddress("Center Street");
 		owner.setCity("New York");
 		owner.setTelephone("0123456789");
+		owner.setEmail("john.doe@example.com");
 
 		when(owners.findById(pathOwnerId)).thenReturn(Optional.of(owner));
 

--- a/src/test/java/org/springframework/samples/petclinic/owner/OwnerRestControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/owner/OwnerRestControllerTests.java
@@ -69,6 +69,7 @@ class OwnerRestControllerTests {
 		owner1.setAddress("110 W. Liberty St.");
 		owner1.setCity("Madison");
 		owner1.setTelephone("6085551023");
+		owner1.setEmail("george.franklin@example.com");
 
 		Owner owner2 = new Owner();
 		owner2.setId(2);
@@ -77,6 +78,7 @@ class OwnerRestControllerTests {
 		owner2.setAddress("638 Cardinal Ave.");
 		owner2.setCity("Sun Prairie");
 		owner2.setTelephone("6085551749");
+		owner2.setEmail("betty.davis@example.com");
 
 		List<Owner> owners = Arrays.asList(owner1, owner2);
 		Page<Owner> ownersPage = new PageImpl<>(owners, PageRequest.of(0, 10), owners.size());
@@ -92,9 +94,11 @@ class OwnerRestControllerTests {
 			.andExpect(jsonPath("$.content[0].id", is(1)))
 			.andExpect(jsonPath("$.content[0].firstName", is("George")))
 			.andExpect(jsonPath("$.content[0].lastName", is("Franklin")))
+			.andExpect(jsonPath("$.content[0].email", is("george.franklin@example.com")))
 			.andExpect(jsonPath("$.content[1].id", is(2)))
 			.andExpect(jsonPath("$.content[1].firstName", is("Betty")))
-			.andExpect(jsonPath("$.content[1].lastName", is("Davis")));
+			.andExpect(jsonPath("$.content[1].lastName", is("Davis")))
+			.andExpect(jsonPath("$.content[1].email", is("betty.davis@example.com")));
 	}
 
 	@Test
@@ -107,6 +111,7 @@ class OwnerRestControllerTests {
 		owner.setAddress("638 Cardinal Ave.");
 		owner.setCity("Sun Prairie");
 		owner.setTelephone("6085551749");
+		owner.setEmail("betty.davis@example.com");
 
 		List<Owner> owners = List.of(owner);
 		Page<Owner> ownersPage = new PageImpl<>(owners, PageRequest.of(0, 10), owners.size());
@@ -121,7 +126,8 @@ class OwnerRestControllerTests {
 			.andExpect(jsonPath("$.content", hasSize(1)))
 			.andExpect(jsonPath("$.content[0].id", is(2)))
 			.andExpect(jsonPath("$.content[0].firstName", is("Betty")))
-			.andExpect(jsonPath("$.content[0].lastName", is("Davis")));
+			.andExpect(jsonPath("$.content[0].lastName", is("Davis")))
+			.andExpect(jsonPath("$.content[0].email", is("betty.davis@example.com")));
 	}
 
 	@Test
@@ -170,6 +176,7 @@ class OwnerRestControllerTests {
 		newOwner.setAddress("123 Main St");
 		newOwner.setCity("Anytown");
 		newOwner.setTelephone("1234567890");
+		newOwner.setEmail("john.doe@example.com");
 
 		given(this.ownerRepository.save(any(Owner.class))).willAnswer(invocation -> {
 			Owner savedOwner = invocation.getArgument(0);
@@ -180,7 +187,7 @@ class OwnerRestControllerTests {
 		// when
 		mockMvc.perform(post("/api/v1/owners").contentType(MediaType.APPLICATION_JSON)
 			.content(
-					"{\"firstName\":\"John\",\"lastName\":\"Doe\",\"address\":\"123 Main St\",\"city\":\"Anytown\",\"telephone\":\"1234567890\"}"))
+					"{\"firstName\":\"John\",\"lastName\":\"Doe\",\"address\":\"123 Main St\",\"city\":\"Anytown\",\"telephone\":\"1234567890\",\"email\":\"john.doe@example.com\"}"))
 			// then
 			.andExpect(status().isCreated())
 			.andExpect(header().string("Location", containsString("/api/v1/owners/10")))
@@ -189,7 +196,8 @@ class OwnerRestControllerTests {
 			.andExpect(jsonPath("$.lastName", is("Doe")))
 			.andExpect(jsonPath("$.address", is("123 Main St")))
 			.andExpect(jsonPath("$.city", is("Anytown")))
-			.andExpect(jsonPath("$.telephone", is("1234567890")));
+			.andExpect(jsonPath("$.telephone", is("1234567890")))
+			.andExpect(jsonPath("$.email", is("john.doe@example.com")));
 
 		verify(this.ownerRepository).save(any(Owner.class));
 	}
@@ -227,6 +235,7 @@ class OwnerRestControllerTests {
 		existingOwner.setAddress("110 W. Liberty St.");
 		existingOwner.setCity("Madison");
 		existingOwner.setTelephone("6085551023");
+		existingOwner.setEmail("george.franklin@example.com");
 
 		given(this.ownerRepository.findById(1)).willReturn(Optional.of(existingOwner));
 		given(this.ownerRepository.save(any(Owner.class))).willAnswer(invocation -> invocation.getArgument(0));
@@ -234,7 +243,7 @@ class OwnerRestControllerTests {
 		// when
 		mockMvc.perform(put("/api/v1/owners/1").contentType(MediaType.APPLICATION_JSON)
 			.content(
-					"{\"firstName\":\"George Updated\",\"lastName\":\"Franklin\",\"address\":\"110 W. Liberty St.\",\"city\":\"Madison\",\"telephone\":\"6085551023\"}"))
+					"{\"firstName\":\"George Updated\",\"lastName\":\"Franklin\",\"address\":\"110 W. Liberty St.\",\"city\":\"Madison\",\"telephone\":\"6085551023\",\"email\":\"george.franklin@example.com\"}"))
 			// then
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.id", is(1)))
@@ -242,7 +251,8 @@ class OwnerRestControllerTests {
 			.andExpect(jsonPath("$.lastName", is("Franklin")))
 			.andExpect(jsonPath("$.address", is("110 W. Liberty St.")))
 			.andExpect(jsonPath("$.city", is("Madison")))
-			.andExpect(jsonPath("$.telephone", is("6085551023")));
+			.andExpect(jsonPath("$.telephone", is("6085551023")))
+			.andExpect(jsonPath("$.email", is("george.franklin@example.com")));
 
 		verify(this.ownerRepository).save(any(Owner.class));
 	}
@@ -255,7 +265,7 @@ class OwnerRestControllerTests {
 		// when
 		mockMvc.perform(put("/api/v1/owners/999").contentType(MediaType.APPLICATION_JSON)
 			.content(
-					"{\"firstName\":\"George Updated\",\"lastName\":\"Franklin\",\"address\":\"110 W. Liberty St.\",\"city\":\"Madison\",\"telephone\":\"6085551023\"}"))
+					"{\"firstName\":\"George Updated\",\"lastName\":\"Franklin\",\"address\":\"110 W. Liberty St.\",\"city\":\"Madison\",\"telephone\":\"6085551023\",\"email\":\"george.franklin@example.com\"}"))
 			// then
 			.andExpect(status().isNotFound());
 


### PR DESCRIPTION
Add an email field to the owner data model. Modify the database schemas for all supported databases to include the new email column. Update the owner form to include an input for the email address and ensure it is validated. Update the owner details and owners list templates to display the email information.

FAIL_TO_PASS: org.springframework.samples.petclinic.model.ValidatorTests, org.springframework.samples.petclinic.owner.OwnerControllerTests, org.springframework.samples.petclinic.owner.OwnerRestControllerTests