### PR TITLE
Custom Constraint Annotation for Address Validation #41

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/model/validation/ValidAddress.java
+++ b/src/main/java/org/springframework/samples/petclinic/model/validation/ValidAddress.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2012-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.samples.petclinic.model.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Custom constraint annotation for validating address format. An address must contain at
+ * least a street number and street name.
+ */
+@Documented
+@Constraint(validatedBy = ValidAddressValidator.class)
+@Target({ ElementType.FIELD })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidAddress {
+
+	String message() default "{address.invalid}";
+
+	Class<?>[] groups() default {};
+
+	Class<? extends Payload>[] payload() default {};
+
+}

--- a/src/main/java/org/springframework/samples/petclinic/model/validation/ValidAddressValidator.java
+++ b/src/main/java/org/springframework/samples/petclinic/model/validation/ValidAddressValidator.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2012-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.samples.petclinic.model.validation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import java.util.regex.Pattern;
+
+/**
+ * Validator for {@link ValidAddress} constraint. Validates that an address contains at
+ * least a street number and street name.
+ */
+public class ValidAddressValidator implements ConstraintValidator<ValidAddress, String> {
+
+	// Pattern to match an address with at least a number followed by some text
+	// This ensures the address has at least a street number and street name
+	private static final Pattern ADDRESS_PATTERN = Pattern.compile("^\\d+\\s+\\w+.*$");
+
+	@Override
+	public void initialize(ValidAddress constraintAnnotation) {
+		// No initialization needed
+	}
+
+	@Override
+	public boolean isValid(String address, ConstraintValidatorContext context) {
+		// Null values are handled by @NotBlank
+		if (address == null) {
+			return true;
+		}
+
+		// Check if the address matches our pattern
+		return ADDRESS_PATTERN.matcher(address).matches();
+	}
+
+}

--- a/src/main/java/org/springframework/samples/petclinic/owner/Owner.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/Owner.java
@@ -33,6 +33,7 @@ import jakarta.persistence.Table;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.NotBlank;
+import org.springframework.samples.petclinic.model.validation.ValidAddress;
 
 /**
  * Simple JavaBean domain object representing an owner.
@@ -50,6 +51,7 @@ public class Owner extends Person {
 
 	@Column(name = "address")
 	@NotBlank
+	@ValidAddress
 	private String address;
 
 	@Column(name = "city")

--- a/src/main/resources/messages/messages.properties
+++ b/src/main/resources/messages/messages.properties
@@ -31,6 +31,7 @@ pets=Pets
 home=Home
 error=Error
 telephone.invalid=Telephone must be a 10-digit number
+address.invalid=Address must contain a street number followed by a street name
 layoutTitle=PetClinic :: a Spring Framework demonstration
 pet=Pet
 birthDate=Birth Date

--- a/src/test/java/org/springframework/samples/petclinic/model/ValidatorTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/model/ValidatorTests.java
@@ -95,4 +95,41 @@ class ValidatorTests {
 		assertThat(violation.getMessage()).isEqualTo("must be a well-formed email address");
 	}
 
+	@Test
+	void shouldValidateWhenAddressFormatIsValid() {
+		LocaleContextHolder.setLocale(Locale.ENGLISH);
+		Owner owner = new Owner();
+		owner.setFirstName("John");
+		owner.setLastName("Doe");
+		owner.setAddress("123 Main St");
+		owner.setCity("New York");
+		owner.setTelephone("1234567890");
+		owner.setEmail("john.doe@example.com");
+
+		Validator validator = createValidator();
+		Set<ConstraintViolation<Owner>> constraintViolations = validator.validate(owner);
+
+		assertThat(constraintViolations).isEmpty();
+	}
+
+	@Test
+	void shouldNotValidateWhenAddressFormatIsInvalid() {
+		LocaleContextHolder.setLocale(Locale.ENGLISH);
+		Owner owner = new Owner();
+		owner.setFirstName("John");
+		owner.setLastName("Doe");
+		owner.setAddress("Main Street"); // Missing street number
+		owner.setCity("New York");
+		owner.setTelephone("1234567890");
+		owner.setEmail("john.doe@example.com");
+
+		Validator validator = createValidator();
+		Set<ConstraintViolation<Owner>> constraintViolations = validator.validate(owner);
+
+		assertThat(constraintViolations).hasSize(1);
+		ConstraintViolation<Owner> violation = constraintViolations.iterator().next();
+		assertThat(violation.getPropertyPath()).hasToString("address");
+		assertThat(violation.getMessage()).isEqualTo("{address.invalid}");
+	}
+
 }


### PR DESCRIPTION
Create a custom constraint annotation for validating address formats in the application. The annotation should ensure that an address contains at least a street number followed by a street name. Implement a validator class that utilizes a regular expression to check the validity of the address format. Apply this annotation to the address field in the Owner class and update the message properties file to include a descriptive error message for invalid addresses.

FAIL_TO_PASS: org.springframework.samples.petclinic.model.ValidatorTests