### PR TITLE
Customize Validation Error Responses #43

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/system/GlobalExceptionHandler.java
+++ b/src/main/java/org/springframework/samples/petclinic/system/GlobalExceptionHandler.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2012-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.samples.petclinic.system;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+/**
+ * Global exception handler for REST controllers. Provides custom error responses for
+ * validation errors.
+ *
+ * @author Junie
+ */
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+	/**
+	 * Handle validation exceptions thrown by @Valid annotation
+	 * @param ex the exception
+	 * @return a ResponseEntity with a custom validation error response
+	 */
+	@ExceptionHandler(MethodArgumentNotValidException.class)
+	public ResponseEntity<ValidationErrorResponse> handleValidationExceptions(MethodArgumentNotValidException ex) {
+		BindingResult bindingResult = ex.getBindingResult();
+
+		ValidationErrorResponse errorResponse = new ValidationErrorResponse(HttpStatus.BAD_REQUEST.value(),
+				"Validation Error", "The request contains invalid data");
+
+		// Extract field errors from BindingResult
+		for (FieldError fieldError : bindingResult.getFieldErrors()) {
+			errorResponse.addFieldError(fieldError.getField(), fieldError.getDefaultMessage());
+		}
+
+		return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+	}
+
+}

--- a/src/main/java/org/springframework/samples/petclinic/system/ValidationError.java
+++ b/src/main/java/org/springframework/samples/petclinic/system/ValidationError.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2012-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.samples.petclinic.system;
+
+/**
+ * Simple JavaBean object that represents a field-level validation error. Used to provide
+ * detailed validation information in API responses.
+ *
+ * @author Junie
+ */
+public class ValidationError {
+
+	private String field;
+
+	private String message;
+
+	/**
+	 * Default constructor
+	 */
+	public ValidationError() {
+	}
+
+	/**
+	 * Constructor with field and message
+	 * @param field the field name that has the validation error
+	 * @param message the validation error message
+	 */
+	public ValidationError(String field, String message) {
+		this.field = field;
+		this.message = message;
+	}
+
+	/**
+	 * Get the field name
+	 * @return the field name
+	 */
+	public String getField() {
+		return field;
+	}
+
+	/**
+	 * Set the field name
+	 * @param field the field name
+	 */
+	public void setField(String field) {
+		this.field = field;
+	}
+
+	/**
+	 * Get the error message
+	 * @return the error message
+	 */
+	public String getMessage() {
+		return message;
+	}
+
+	/**
+	 * Set the error message
+	 * @param message the error message
+	 */
+	public void setMessage(String message) {
+		this.message = message;
+	}
+
+}

--- a/src/main/java/org/springframework/samples/petclinic/system/ValidationErrorResponse.java
+++ b/src/main/java/org/springframework/samples/petclinic/system/ValidationErrorResponse.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2012-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.samples.petclinic.system;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Simple JavaBean object that represents a validation error response. Contains metadata
+ * about the error and a list of field-level validation errors.
+ *
+ * @author Junie
+ */
+public class ValidationErrorResponse {
+
+	private LocalDateTime timestamp;
+
+	private int status;
+
+	private String error;
+
+	private String message;
+
+	private List<ValidationError> fieldErrors = new ArrayList<>();
+
+	/**
+	 * Default constructor
+	 */
+	public ValidationErrorResponse() {
+		this.timestamp = LocalDateTime.now();
+	}
+
+	/**
+	 * Constructor with status, error, and message
+	 * @param status the HTTP status code
+	 * @param error the error type
+	 * @param message the error message
+	 */
+	public ValidationErrorResponse(int status, String error, String message) {
+		this.timestamp = LocalDateTime.now();
+		this.status = status;
+		this.error = error;
+		this.message = message;
+	}
+
+	/**
+	 * Add a field error to the response
+	 * @param field the field name
+	 * @param message the error message
+	 */
+	public void addFieldError(String field, String message) {
+		this.fieldErrors.add(new ValidationError(field, message));
+	}
+
+	/**
+	 * Get the timestamp
+	 * @return the timestamp
+	 */
+	public LocalDateTime getTimestamp() {
+		return timestamp;
+	}
+
+	/**
+	 * Set the timestamp
+	 * @param timestamp the timestamp
+	 */
+	public void setTimestamp(LocalDateTime timestamp) {
+		this.timestamp = timestamp;
+	}
+
+	/**
+	 * Get the HTTP status code
+	 * @return the status code
+	 */
+	public int getStatus() {
+		return status;
+	}
+
+	/**
+	 * Set the HTTP status code
+	 * @param status the status code
+	 */
+	public void setStatus(int status) {
+		this.status = status;
+	}
+
+	/**
+	 * Get the error type
+	 * @return the error type
+	 */
+	public String getError() {
+		return error;
+	}
+
+	/**
+	 * Set the error type
+	 * @param error the error type
+	 */
+	public void setError(String error) {
+		this.error = error;
+	}
+
+	/**
+	 * Get the error message
+	 * @return the error message
+	 */
+	public String getMessage() {
+		return message;
+	}
+
+	/**
+	 * Set the error message
+	 * @param message the error message
+	 */
+	public void setMessage(String message) {
+		this.message = message;
+	}
+
+	/**
+	 * Get the list of field errors
+	 * @return the list of field errors
+	 */
+	public List<ValidationError> getFieldErrors() {
+		return fieldErrors;
+	}
+
+	/**
+	 * Set the list of field errors
+	 * @param fieldErrors the list of field errors
+	 */
+	public void setFieldErrors(List<ValidationError> fieldErrors) {
+		this.fieldErrors = fieldErrors;
+	}
+
+}


### PR DESCRIPTION
Implement a global exception handler for REST controllers to customize validation error responses. Create a ValidationErrorResponse class to encapsulate details about validation errors, including timestamps, status codes, and field-level errors. Define a ValidationError class to represent individual field errors. Ensure that when a MethodArgumentNotValidException is thrown, the handler returns a structured and informative response that includes all validation error details.