### PR TITLE
Upgrade to Spring Boot 3.4 #79

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,11 +8,13 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.0.0</version>
+    <version>3.4.8</version>
   </parent>
   <name>petclinic</name>
 
   <properties>
+    <maven.compiler.source>${java.version}</maven.compiler.source>
+    <maven.compiler.target>${java.version}</maven.compiler.target>
 
     <!-- Generic properties -->
     <java.version>17</java.version>
@@ -23,7 +25,7 @@
     <webjars-bootstrap.version>5.1.3</webjars-bootstrap.version>
     <webjars-font-awesome.version>4.7.0</webjars-font-awesome.version>
 
-    <jacoco.version>0.8.7</jacoco.version>
+    <jacoco.version>0.8.13</jacoco.version>
     <nohttp-checkstyle.version>0.0.10</nohttp-checkstyle.version>
     <spring-format.version>0.0.31</spring-format.version>
 
@@ -115,16 +117,23 @@
     <dependency>
       <groupId>org.springdoc</groupId>
       <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-      <version>2.1.0</version>
+      <version>2.8.9</version>
     </dependency>
     <dependency>
       <groupId>org.webjars</groupId>
-      <artifactId>webjars-locator-core</artifactId>
-      <version>0.59</version>
+      <artifactId>webjars-locator-lite</artifactId>
     </dependency>
     <dependency>
       <groupId>org.flywaydb</groupId>
       <artifactId>flyway-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.flywaydb</groupId>
+      <artifactId>flyway-database-postgresql</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.flywaydb</groupId>
+      <artifactId>flyway-mysql</artifactId>
     </dependency>
   </dependencies>
 
@@ -146,7 +155,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>3.1.2</version>
+        <version>3.6.0</version>
         <dependencies>
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>

--- a/src/main/java/org/springframework/samples/petclinic/config/RestTemplateConfig.java
+++ b/src/main/java/org/springframework/samples/petclinic/config/RestTemplateConfig.java
@@ -27,13 +27,13 @@ public class RestTemplateConfig {
 
 	@Bean
 	public RestTemplate customRestTemplate(RestTemplateBuilder builder) {
-		return builder.setConnectTimeout(Duration.ofSeconds(30)).setReadTimeout(Duration.ofSeconds(60))
+		return builder.connectTimeout(Duration.ofSeconds(30)).readTimeout(Duration.ofSeconds(60))
 				.rootUri("https://petclinic-api.example.com").build();
 	}
 
 	@Bean("externalApiRestTemplate")
 	public RestTemplate externalApiRestTemplate(RestTemplateBuilder builder) {
-		return builder.setConnectTimeout(Duration.ofSeconds(10)).setReadTimeout(Duration.ofSeconds(30))
+		return builder.connectTimeout(Duration.ofSeconds(10)).readTimeout(Duration.ofSeconds(30))
 				.rootUri("https://api.example.com").build();
 	}
 

--- a/src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java
@@ -16,7 +16,6 @@
 package org.springframework.samples.petclinic.owner;
 
 import jakarta.validation.Valid;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -43,7 +42,6 @@ class OwnerController {
 
 	private final OwnerRepository owners;
 
-	@Autowired
 	public OwnerController(OwnerRepository clinicService) {
 		this.owners = clinicService;
 	}

--- a/src/main/java/org/springframework/samples/petclinic/owner/PetTypeFormatter.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/PetTypeFormatter.java
@@ -15,7 +15,6 @@
  */
 package org.springframework.samples.petclinic.owner;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.format.Formatter;
 import org.springframework.stereotype.Component;
 
@@ -38,7 +37,6 @@ public class PetTypeFormatter implements Formatter<PetType> {
 
 	private final OwnerRepository owners;
 
-	@Autowired
 	public PetTypeFormatter(OwnerRepository owners) {
 		this.owners = owners;
 	}

--- a/src/main/java/org/springframework/samples/petclinic/owner/PetValidator.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/PetValidator.java
@@ -15,10 +15,11 @@
  */
 package org.springframework.samples.petclinic.owner;
 
-import org.springframework.util.Base64Utils;
 import org.springframework.util.StringUtils;
 import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
+
+import java.util.Base64;
 
 /**
  * <code>Validator</code> for <code>Pet</code> forms.
@@ -63,11 +64,11 @@ public class PetValidator implements Validator {
 	}
 
 	public String encode(String value) {
-		return Base64Utils.encodeToString("hola".getBytes());
+		return Base64.getEncoder().encodeToString("hola".getBytes());
 	}
 
 	public String decode(String value) {
-		return new String(Base64Utils.decodeFromString(value));
+		return new String(Base64.getDecoder().decode(value));
 	}
 
 }

--- a/src/main/java/org/springframework/samples/petclinic/owner/VisitController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/VisitController.java
@@ -16,7 +16,6 @@
 package org.springframework.samples.petclinic.owner;
 
 import jakarta.validation.Valid;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.WebDataBinder;
@@ -36,7 +35,6 @@ class VisitController {
 
 	private final OwnerRepository owners;
 
-	@Autowired
 	public VisitController(OwnerRepository owners) {
 		this.owners = owners;
 	}

--- a/src/main/resources/application-couchbase.properties
+++ b/src/main/resources/application-couchbase.properties
@@ -3,5 +3,7 @@ spring.couchbase.username=username
 spring.couchbase.password=password
 
 spring.couchbase.env.ssl.enabled=true
-spring.couchbase.env.ssl.key-store=classpath:keystore.jks
-spring.couchbase.env.ssl.key-store-password=your-keystore-password
+# This property is deprecated: SSL bundle support with spring.ssl.bundle and spring.couchbase.env.ssl.bundle should be used instead
+# spring.couchbase.env.ssl.key-store=classpath:keystore.jks
+# This property is deprecated: SSL bundle support with spring.ssl.bundle and spring.couchbase.env.ssl.bundle should be used instead
+# spring.couchbase.env.ssl.key-store-password=your-keystore-password

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,7 +7,8 @@ spring.sql.init.mode=never
 spring.flyway.enabled=true
 spring.flyway.locations=classpath:db/migration
 spring.flyway.baseline-on-migrate=true
-spring.flyway.license-key=test-key
+# This property is deprecated: Removed in Flyway 10
+# spring.flyway.license-key=test-key
 
 # Web
 spring.thymeleaf.mode=HTML
@@ -31,8 +32,8 @@ logging.level.org.springframework=INFO
 spring.web.resources.cache.cachecontrol.max-age=12h
 
 # Metrics configuration
-management.metrics.web.server.requests-metric-name=http.server.requests
-management.metrics.web.client.requests-metric-name=http.client.requests
+management.observations.http.server.requests.name=http.server.requests
+management.observations.http.client.requests.name=http.client.requests
 management.metrics.web.client.max-uri-tags=100
 management.metrics.web.server.max-uri-tags=100
 management.metrics.tags.application=petclinic

--- a/src/test/java/org/springframework/samples/petclinic/MigrationTest.java
+++ b/src/test/java/org/springframework/samples/petclinic/MigrationTest.java
@@ -1,0 +1,184 @@
+package org.springframework.samples.petclinic;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.SpringBootVersion;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class MigrationTest {
+
+	@Test
+	public void testSpringBootVersion() {
+		String springBootVersion = SpringBootVersion.getVersion();
+		assertTrue(springBootVersion.startsWith("3.4."),
+				"Expected Spring Boot version 3.4.x, but found: " + springBootVersion);
+	}
+
+	@Test
+	public void testLibraries() {
+		String springDocVersion = getVersionFromClasspath("org.springdoc", "springdoc-openapi-starter-webmvc-ui");
+		assertNotNull(springDocVersion, "Could not find springdoc-openapi-tests version");
+
+		assertTrue(springDocVersion.startsWith("2.8."),
+				"Expected org.springdoc:springdoc-openapi-tests version 2.8.x, but found: " + springDocVersion);
+
+		String webjarsCoreVersion = getVersionFromClasspath("org.webjars", "webjars-locator-core");
+		assertNull(webjarsCoreVersion, "Found webjars-locator-core version");
+
+		String webjarsLiteVersion = getVersionFromClasspath("org.webjars", "webjars-locator-lite");
+		assertNotNull(webjarsLiteVersion, "Could not find webjars-locator-lite version");
+		assertTrue(webjarsLiteVersion.startsWith("1.0."),
+				"Expected org.webjars:webjars-locator-lite version 1.0.x, but found: " + webjarsLiteVersion);
+
+		String flywayMySqlVersion = getVersionFromClasspath("org.flywaydb", "flyway-mysql");
+		assertNotNull(flywayMySqlVersion, "Could not find flyway-mysql version");
+
+		String flywayPostgresVersion = getVersionFromClasspath("org.flywaydb", "flyway-database-postgresql");
+		assertNotNull(flywayPostgresVersion, "Could not find flyway-postgresql version");
+	}
+
+	private String getVersionFromClasspath(String groupId, String artifactId) {
+		String resourcePath = "META-INF/maven/" + groupId + "/" + artifactId + "/pom.properties";
+		try (InputStream inputStream = getClass().getClassLoader().getResourceAsStream(resourcePath)) {
+			if (inputStream != null) {
+				Properties props = new Properties();
+				props.load(inputStream);
+				return props.getProperty("version");
+			}
+		}
+		catch (IOException e) {
+			System.err
+					.println("Failed to load version info for " + groupId + ":" + artifactId + " - " + e.getMessage());
+		}
+
+		// Fallback: try to get version from Package information
+		try {
+			Package pkg = Package.getPackage(groupId);
+			if (pkg != null) {
+				String version = pkg.getImplementationVersion();
+				if (version != null) {
+					return version;
+				}
+				return pkg.getSpecificationVersion();
+			}
+		}
+		catch (Exception e) {
+			System.err.println("Failed to get package version for " + groupId + " - " + e.getMessage());
+		}
+
+		return null;
+	}
+
+	@Test
+	public void testProperties() throws IOException {
+		Properties appProperties = loadApplicationProperties("");
+		assertNull(appProperties.getProperty("management.metrics.web.client.requests-metric-name"),
+				"Old property 'management.metrics.web.client.requests-metric-name' should not be present");
+		assertNull(appProperties.getProperty("management.metrics.web.server.requests-metric-name"),
+				"Old property 'management.metrics.web.server.requests-metric-name' should not be present");
+
+		assertEquals("http.client.requests",
+				appProperties.getProperty("management.observations.http.client.requests.name"),
+				"New property 'management.observations.http.client.requests.name' should have correct value");
+		assertEquals("http.server.requests",
+				appProperties.getProperty("management.observations.http.server.requests.name"),
+				"New property 'management.observations.http.server.requests.name' should have correct value");
+
+		assertNull(appProperties.getProperty("spring.flyway.license-key"),
+				"Property 'spring.flyway.license-key' should not be active");
+
+		Properties couchbaseProperties = loadApplicationProperties("-couchbase");
+		assertNull(couchbaseProperties.getProperty("spring.couchbase.env.ssl.key-store"),
+				"Property 'spring.couchbase.env.ssl.key-store' should not be active");
+		assertNull(couchbaseProperties.getProperty("spring.couchbase.env.ssl.key-store-password"),
+				"Property 'spring.couchbase.env.ssl.key-store-password' should not be active");
+	}
+
+	private Properties loadApplicationProperties(String suffix) throws IOException {
+		Properties props = new Properties();
+		try (InputStream inputStream = getClass().getClassLoader()
+				.getResourceAsStream("application" + suffix + ".properties")) {
+			assertNotNull(inputStream, "application.properties file should exist");
+			props.load(inputStream);
+		}
+		return props;
+	}
+
+	@Test
+	public void testBeans() throws ClassNotFoundException {
+		// Test that constructors in these classes don't have @Autowired annotation
+		assertConstructorNotAutowired("org.springframework.samples.petclinic.owner.OwnerController");
+		assertConstructorNotAutowired("org.springframework.samples.petclinic.owner.PetTypeFormatter");
+		assertConstructorNotAutowired("org.springframework.samples.petclinic.owner.VisitController");
+	}
+
+	private void assertConstructorNotAutowired(String className) throws ClassNotFoundException {
+		Class<?> clazz = Class.forName(className);
+		java.lang.reflect.Constructor<?>[] constructors = clazz.getDeclaredConstructors();
+
+		for (java.lang.reflect.Constructor<?> constructor : constructors) {
+			// Skip synthetic constructors (e.g., generated by inner classes)
+			if (constructor.isSynthetic()) {
+				continue;
+			}
+
+			// Check if the constructor has @Autowired annotation
+			boolean hasAutowired = constructor
+					.isAnnotationPresent(org.springframework.beans.factory.annotation.Autowired.class);
+
+			assertFalse(hasAutowired, String.format("Constructor in %s should not have @Autowired annotation. "
+					+ "Spring 4.3+ automatically injects dependencies through single constructor without @Autowired.",
+					clazz.getSimpleName()));
+		}
+	}
+
+	@Test
+	public void testImports() throws IOException {
+		// Test that PetValidator imports java.util.Base64 and not
+		// org.springframework.util.Base64Utils
+		String petValidatorSource = loadJavaSourceFile("org.springframework.samples.petclinic.owner.PetValidator");
+
+		// Check that it imports java.util.Base64
+		assertTrue(petValidatorSource.contains("import java.util.Base64;"),
+				"PetValidator should import java.util.Base64");
+
+		// Check that it does NOT import org.springframework.util.Base64Utils (deprecated)
+		assertFalse(petValidatorSource.contains("import org.springframework.util.Base64Utils;"),
+				"PetValidator should not import deprecated org.springframework.util.Base64Utils");
+
+		// Verify the source uses Base64.getEncoder() and Base64.getDecoder() (modern API)
+		assertTrue(petValidatorSource.contains("Base64.getEncoder()"),
+				"PetValidator should use Base64.getEncoder() (modern API)");
+		assertTrue(petValidatorSource.contains("Base64.getDecoder()"),
+				"PetValidator should use Base64.getDecoder() (modern API)");
+
+		// Verify it does NOT use the old Base64Utils methods
+		assertFalse(petValidatorSource.contains("Base64Utils.encodeToString"),
+				"PetValidator should not use deprecated Base64Utils.encodeToString");
+		assertFalse(petValidatorSource.contains("Base64Utils.decodeFromString"),
+				"PetValidator should not use deprecated Base64Utils.decodeFromString");
+	}
+
+	private String loadJavaSourceFile(String className) throws IOException {
+		String filePath = "src/main/java/" + className.replace('.', '/') + ".java";
+		try (InputStream inputStream = new java.io.FileInputStream(filePath)) {
+			return new String(inputStream.readAllBytes());
+		}
+	}
+
+	@Test
+	public void testRestTemplate() throws IOException {
+		String restTemplateConfigSource = loadJavaSourceFile(
+				"org.springframework.samples.petclinic.config.RestTemplateConfig");
+
+		assertFalse(restTemplateConfigSource.contains(".setConnectTimeout("));
+		assertFalse(restTemplateConfigSource.contains(".setReadTimeout("));
+		assertTrue(restTemplateConfigSource.contains(".connectTimeout("));
+		assertTrue(restTemplateConfigSource.contains(".readTimeout("));
+	}
+
+}


### PR DESCRIPTION
- Upgrade Spring Boot to the latest 3.4.x.
- Align dependencies via Spring Boot BOM; remove explicit versions managed by the BOM.
- Adjust application configuration properties for changes introduced in 3.1–3.4.
- Migrate usages of deprecated APIs to their current equivalents.
- Remove annotations that are redundant or obsolete in 3.4.x.
- Migrate/replace annotations to the new APIs where applicable.