### PR TITLE
Create Recipe entity with manyToOne reference to Visit

### DIFF
--- a/.ee-bench/codegen/metadata.json
+++ b/.ee-bench/codegen/metadata.json
@@ -4,7 +4,9 @@
   "language": "java",
   "jvm_version": "17",
   "expected": {
-    "fail_to_pass": [],
+    "fail_to_pass": [
+      "org.springframework.samples.petclinic.owner.RecipeTest"
+    ],
     "pass_to_pass": []
   },
   "environment": {

--- a/src/main/java/org/springframework/samples/petclinic/owner/Recipe.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/Recipe.java
@@ -1,0 +1,59 @@
+package org.springframework.samples.petclinic.owner;
+
+import jakarta.persistence.*;
+import org.hibernate.proxy.HibernateProxy;
+import org.springframework.samples.petclinic.model.BaseEntity;
+
+import java.util.Objects;
+
+@Entity
+@Table(name = "recipe")
+public class Recipe extends BaseEntity {
+
+	@Column(name = "text")
+	private String text;
+
+	@ManyToOne
+	@JoinColumn(name = "visit_id")
+	private Visit visit;
+
+	public Visit getVisit() {
+		return visit;
+	}
+
+	public void setVisit(Visit visit) {
+		this.visit = visit;
+	}
+
+	public String getText() {
+		return text;
+	}
+
+	public void setText(String text) {
+		this.text = text;
+	}
+
+	@Override
+	public final boolean equals(Object o) {
+		if (this == o)
+			return true;
+		if (o == null)
+			return false;
+		Class<?> oEffectiveClass = o instanceof HibernateProxy
+				? ((HibernateProxy) o).getHibernateLazyInitializer().getPersistentClass() : o.getClass();
+		Class<?> thisEffectiveClass = this instanceof HibernateProxy
+				? ((HibernateProxy) this).getHibernateLazyInitializer().getPersistentClass() : this.getClass();
+		if (thisEffectiveClass != oEffectiveClass)
+			return false;
+		Recipe recipe = (Recipe) o;
+		return getId() != null && Objects.equals(getId(), recipe.getId());
+	}
+
+	@Override
+	public final int hashCode() {
+		return this instanceof HibernateProxy
+				? ((HibernateProxy) this).getHibernateLazyInitializer().getPersistentClass().hashCode()
+				: getClass().hashCode();
+	}
+
+}

--- a/src/main/java/org/springframework/samples/petclinic/owner/RecipeRepository.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/RecipeRepository.java
@@ -1,0 +1,11 @@
+package org.springframework.samples.petclinic.owner;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface RecipeRepository extends JpaRepository<Recipe, Long> {
+
+	List<Recipe> findAllByVisitId(int visitId);
+
+}

--- a/src/main/java/org/springframework/samples/petclinic/owner/Visit.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/Visit.java
@@ -16,13 +16,13 @@
 package org.springframework.samples.petclinic.owner;
 
 import java.time.LocalDate;
+import java.util.LinkedHashSet;
+import java.util.Set;
 
+import jakarta.persistence.*;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.samples.petclinic.model.BaseEntity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotBlank;
 
 /**
@@ -41,6 +41,17 @@ public class Visit extends BaseEntity {
 
 	@NotBlank
 	private String description;
+
+	@OneToMany(mappedBy = "visit", cascade = CascadeType.ALL, orphanRemoval = true)
+	private Set<Recipe> recipes = new LinkedHashSet<>();
+
+	public Set<Recipe> getRecipes() {
+		return recipes;
+	}
+
+	public void setRecipes(Set<Recipe> recipes) {
+		this.recipes = recipes;
+	}
 
 	/**
 	 * Creates a new instance of Visit for the current date

--- a/src/main/java/org/springframework/samples/petclinic/owner/VisitRepository.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/VisitRepository.java
@@ -1,0 +1,7 @@
+package org.springframework.samples.petclinic.owner;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface VisitRepository extends JpaRepository<Visit, Integer> {
+
+}

--- a/src/main/resources/db/h2/schema.sql
+++ b/src/main/resources/db/h2/schema.sql
@@ -62,3 +62,14 @@ CREATE TABLE visits (
 );
 ALTER TABLE visits ADD CONSTRAINT fk_visits_pets FOREIGN KEY (pet_id) REFERENCES pets (id);
 CREATE INDEX visits_pet_id ON visits (pet_id);
+
+CREATE TABLE recipe
+(
+  id       BIGINT AUTO_INCREMENT NOT NULL,
+  text     VARCHAR(255)          NULL,
+  visit_id INT                   NULL,
+  CONSTRAINT pk_recipe PRIMARY KEY (id)
+);
+
+ALTER TABLE recipe
+  ADD CONSTRAINT FK_RECIPE_ON_VISIT FOREIGN KEY (visit_id) REFERENCES visits (id);

--- a/src/test/java/org/springframework/samples/petclinic/owner/RecipeTest.java
+++ b/src/test/java/org/springframework/samples/petclinic/owner/RecipeTest.java
@@ -1,0 +1,39 @@
+package org.springframework.samples.petclinic.owner;
+
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+public class RecipeTest {
+
+	@Autowired
+	private VisitRepository visitRepository;
+
+	@Autowired
+	private RecipeRepository recipeRepository;
+
+	@Test
+	@Transactional(Transactional.TxType.NEVER)
+	void testSaveVisitWithRecipe() {
+		Visit visit = visitRepository.findById(1).get();
+		Recipe recipe = new Recipe();
+		recipe.setText("Test");
+		recipe.setVisit(visit);
+
+		recipeRepository.save(recipe);
+		List<Recipe> recipes = recipeRepository.findAllByVisitId(visit.getId());
+		assertEquals(1, recipes.size());
+		assertEquals("Test", recipes.iterator().next().getText());
+
+		visitRepository.delete(visitRepository.findById(1).get());
+		recipes = recipeRepository.findAllByVisitId(visit.getId());
+		assertEquals(0, recipes.size());
+	}
+
+}


### PR DESCRIPTION
Create a `Recipe` domain entity with `id` and `text` fields. Add a many-to-one association from the `Recipe` to the `Visit` entity. Add a back reference field to the `Visit` entity. Adjust cascade and orphan removing strategies.

Write tests to verify relationship integrity and cascading behavior.