### PR TITLE
Add prescriptions embedded list to Visit #22

### DIFF
--- a/.ee-bench/codegen/metadata.json
+++ b/.ee-bench/codegen/metadata.json
@@ -4,7 +4,9 @@
   "language": "java",
   "jvm_version": "17",
   "expected": {
-    "fail_to_pass": [],
+    "fail_to_pass": [
+      "org.springframework.samples.petclinic.owner.VisitTest"
+    ],
     "pass_to_pass": []
   },
   "environment": {

--- a/src/main/java/org/springframework/samples/petclinic/owner/Prescription.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/Prescription.java
@@ -1,0 +1,10 @@
+package org.springframework.samples.petclinic.owner;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+
+@Embeddable
+public record Prescription(@Column(name = "medicine") String medicine,
+
+		@Column(name = "notes") String notes) {
+}

--- a/src/main/java/org/springframework/samples/petclinic/owner/Visit.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/Visit.java
@@ -16,13 +16,13 @@
 package org.springframework.samples.petclinic.owner;
 
 import java.time.LocalDate;
+import java.util.LinkedHashSet;
+import java.util.Set;
 
+import jakarta.persistence.*;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.samples.petclinic.model.BaseEntity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotBlank;
 
 /**
@@ -41,6 +41,18 @@ public class Visit extends BaseEntity {
 
 	@NotBlank
 	private String description;
+
+	@ElementCollection(fetch = FetchType.EAGER)
+	@CollectionTable(name = "visit_prescriptions", joinColumns = @JoinColumn(name = "visit_id"))
+	private Set<Prescription> prescription = new LinkedHashSet<>();
+
+	public Set<Prescription> getPrescription() {
+		return prescription;
+	}
+
+	public void setPrescription(Set<Prescription> prescription) {
+		this.prescription = prescription;
+	}
 
 	/**
 	 * Creates a new instance of Visit for the current date

--- a/src/main/resources/db/h2/schema.sql
+++ b/src/main/resources/db/h2/schema.sql
@@ -62,3 +62,13 @@ CREATE TABLE visits (
 );
 ALTER TABLE visits ADD CONSTRAINT fk_visits_pets FOREIGN KEY (pet_id) REFERENCES pets (id);
 CREATE INDEX visits_pet_id ON visits (pet_id);
+
+CREATE TABLE visit_prescriptions
+(
+  visit_id INT NOT NULL,
+  medicine VARCHAR(255),
+  notes    VARCHAR(255)
+);
+
+ALTER TABLE visit_prescriptions
+  ADD CONSTRAINT fk_visit_prescriptions_on_visit FOREIGN KEY (visit_id) REFERENCES visits (id);

--- a/src/test/java/org/springframework/samples/petclinic/owner/VisitTest.java
+++ b/src/test/java/org/springframework/samples/petclinic/owner/VisitTest.java
@@ -1,0 +1,46 @@
+package org.springframework.samples.petclinic.owner;
+
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DataJpaTest
+public class VisitTest {
+
+	@Autowired
+	private OwnerRepository ownerRepository;
+
+	@Test
+	@Transactional(Transactional.TxType.NEVER)
+	void testVisitPrescriptions() {
+		Owner owner = ownerRepository.findById(6).get();
+		Visit visit = owner.getPet(7).getVisits().iterator().next();
+		visit.getPrescription().add(new Prescription("Aaa", "111"));
+		visit.getPrescription().add(new Prescription("Bbb", "222"));
+		ownerRepository.save(owner);
+
+		owner = ownerRepository.findById(6).get();
+		visit = owner.getPet(7).getVisits().iterator().next();
+		assertEquals(2, visit.getPrescription().size());
+		assertTrue(visit.getPrescription().contains(new Prescription("Aaa", "111")));
+		assertTrue(visit.getPrescription().contains(new Prescription("Bbb", "222")));
+
+		visit.setPrescription(
+				Set.of(new Prescription("Aaa", "001"), new Prescription("Bbb", "222"), new Prescription("Ccc", "333")));
+		ownerRepository.save(owner);
+
+		owner = ownerRepository.findById(6).get();
+		visit = owner.getPet(7).getVisits().iterator().next();
+		assertEquals(3, visit.getPrescription().size());
+		assertTrue(visit.getPrescription().contains(new Prescription("Aaa", "001")));
+		assertTrue(visit.getPrescription().contains(new Prescription("Bbb", "222")));
+		assertTrue(visit.getPrescription().contains(new Prescription("Ccc", "333")));
+	}
+
+}


### PR DESCRIPTION
Create a new Prescription value object as an embeddable record and embed a collection of it within the Visit entity.
Ensure that a Visit can persist and retrieve multiple Prescription entries correctly through standard JPA repository operations.