### PR TITLE
Identify and Resolve the N+1 Select Problem in Petclinic JPA Entities #90

### DIFF
--- a/.ee-bench/codegen/metadata.json
+++ b/.ee-bench/codegen/metadata.json
@@ -4,7 +4,9 @@
   "language": "java",
   "jvm_version": "17",
   "expected": {
-    "fail_to_pass": [],
+    "fail_to_pass": [
+      "org.springframework.samples.petclinic.PetClinicIntegrationDatabaseTests.testOwnerDetails"
+    ],
     "pass_to_pass": []
   },
   "environment": {

--- a/src/main/java/org/springframework/samples/petclinic/owner/Owner.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/Owner.java
@@ -15,8 +15,8 @@
  */
 package org.springframework.samples.petclinic.owner;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 
 import org.springframework.core.style.ToStringCreator;
 import org.springframework.samples.petclinic.model.Person;
@@ -63,7 +63,7 @@ public class Owner extends Person {
 	@OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER)
 	@JoinColumn(name = "owner_id")
 	@OrderBy("name")
-	private final List<Pet> pets = new ArrayList<>();
+	private final Set<Pet> pets = new HashSet<>();
 
 	public String getAddress() {
 		return this.address;
@@ -89,7 +89,7 @@ public class Owner extends Person {
 		this.telephone = telephone;
 	}
 
-	public List<Pet> getPets() {
+	public Set<Pet> getPets() {
 		return this.pets;
 	}
 

--- a/src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java
@@ -18,6 +18,8 @@ package org.springframework.samples.petclinic.owner;
 import java.util.List;
 import java.util.Optional;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -62,9 +64,9 @@ class OwnerController {
 	@ModelAttribute("owner")
 	public Owner findOwner(@PathVariable(name = "ownerId", required = false) Integer ownerId) {
 		return ownerId == null ? new Owner()
-				: this.owners.findById(ownerId)
-					.orElseThrow(() -> new IllegalArgumentException("Owner not found with id: " + ownerId
-							+ ". Please ensure the ID is correct " + "and the owner exists in the database."));
+			: this.owners.findById(ownerId)
+			.orElseThrow(() -> new IllegalArgumentException("Owner not found with id: " + ownerId
+				+ ". Please ensure the ID is correct " + "and the owner exists in the database."));
 	}
 
 	@GetMapping("/owners/new")
@@ -161,13 +163,11 @@ class OwnerController {
 	 * @return a ModelMap with the model attributes for the view
 	 */
 	@GetMapping("/owners/{ownerId}")
-	public ModelAndView showOwner(@PathVariable("ownerId") int ownerId) {
-		ModelAndView mav = new ModelAndView("owners/ownerDetails");
-		Optional<Owner> optionalOwner = this.owners.findById(ownerId);
-		Owner owner = optionalOwner.orElseThrow(() -> new IllegalArgumentException(
-				"Owner not found with id: " + ownerId + ". Please ensure the ID is correct "));
-		mav.addObject(owner);
-		return mav;
+	public ModelAndView showOwner(
+		@PathVariable("ownerId") int ownerId,
+		@ModelAttribute("owner") Owner owner
+	) {
+		return new ModelAndView("owners/ownerDetails").addObject(owner);
 	}
 
 }

--- a/src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java
@@ -64,9 +64,9 @@ class OwnerController {
 	@ModelAttribute("owner")
 	public Owner findOwner(@PathVariable(name = "ownerId", required = false) Integer ownerId) {
 		return ownerId == null ? new Owner()
-			: this.owners.findById(ownerId)
-			.orElseThrow(() -> new IllegalArgumentException("Owner not found with id: " + ownerId
-				+ ". Please ensure the ID is correct " + "and the owner exists in the database."));
+				: this.owners.findById(ownerId)
+					.orElseThrow(() -> new IllegalArgumentException("Owner not found with id: " + ownerId
+							+ ". Please ensure the ID is correct " + "and the owner exists in the database."));
 	}
 
 	@GetMapping("/owners/new")
@@ -163,10 +163,7 @@ class OwnerController {
 	 * @return a ModelMap with the model attributes for the view
 	 */
 	@GetMapping("/owners/{ownerId}")
-	public ModelAndView showOwner(
-		@PathVariable("ownerId") int ownerId,
-		@ModelAttribute("owner") Owner owner
-	) {
+	public ModelAndView showOwner(@PathVariable("ownerId") int ownerId, @ModelAttribute("owner") Owner owner) {
 		return new ModelAndView("owners/ownerDetails").addObject(owner);
 	}
 

--- a/src/test/java/org/springframework/samples/petclinic/PetClinicIntegrationDatabaseTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/PetClinicIntegrationDatabaseTests.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2012-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.samples.petclinic;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.RequestEntity;
+import org.springframework.http.ResponseEntity;
+import org.springframework.samples.petclinic.vet.VetRepository;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@TestPropertySource(properties = {
+	"spring.jpa.show-sql=true",
+})
+@ExtendWith(OutputCaptureExtension.class)
+public class PetClinicIntegrationDatabaseTests {
+
+	@LocalServerPort
+	int port;
+
+	@Autowired
+	private VetRepository vets;
+
+	@Autowired
+	private RestTemplateBuilder builder;
+
+
+	@Test
+	void testOwnerDetails(CapturedOutput output) {
+		RestTemplate template = builder.rootUri("http://localhost:" + port).build();
+		ResponseEntity<String> result = template.exchange(RequestEntity.get("/owners/1").build(), String.class);
+		assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+		assertThat(countSelects(output)).isEqualTo(1L);
+	}
+
+	public static void main(String[] args) {
+		SpringApplication.run(PetClinicApplication.class, args);
+	}
+
+	private Long countSelects(CapturedOutput output) {
+		Matcher m = Pattern.compile("select").matcher(output.getAll());
+		Long count = 0L;
+		while (m.find()) count++;
+		return count;
+	}
+}

--- a/src/test/java/org/springframework/samples/petclinic/PetClinicIntegrationDatabaseTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/PetClinicIntegrationDatabaseTests.java
@@ -41,9 +41,7 @@ import java.util.regex.Pattern;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
-@TestPropertySource(properties = {
-	"spring.jpa.show-sql=true",
-})
+@TestPropertySource(properties = { "spring.jpa.show-sql=true", })
 @ExtendWith(OutputCaptureExtension.class)
 public class PetClinicIntegrationDatabaseTests {
 
@@ -55,7 +53,6 @@ public class PetClinicIntegrationDatabaseTests {
 
 	@Autowired
 	private RestTemplateBuilder builder;
-
 
 	@Test
 	void testOwnerDetails(CapturedOutput output) {
@@ -73,7 +70,9 @@ public class PetClinicIntegrationDatabaseTests {
 	private Long countSelects(CapturedOutput output) {
 		Matcher m = Pattern.compile("select").matcher(output.getAll());
 		Long count = 0L;
-		while (m.find()) count++;
+		while (m.find())
+			count++;
 		return count;
 	}
+
 }

--- a/src/test/java/org/springframework/samples/petclinic/service/ClinicServiceTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/service/ClinicServiceTests.java
@@ -100,8 +100,9 @@ class ClinicServiceTests {
 		Owner owner = optionalOwner.get();
 		assertThat(owner.getLastName()).startsWith("Franklin");
 		assertThat(owner.getPets()).hasSize(1);
-		assertThat(owner.getPets().get(0).getType()).isNotNull();
-		assertThat(owner.getPets().get(0).getType().getName()).isEqualTo("cat");
+		Pet firstPet = owner.getPets().iterator().next();
+		assertThat(firstPet.getType()).isNotNull();
+		assertThat(firstPet.getType().getName()).isEqualTo("cat");
 	}
 
 	@Test


### PR DESCRIPTION
Task Description:
Detect and resolve the N+1 select problem in the JPA entity relationships within the Petclinic REST API, such as the Owner-to-Pet-Visit relationship. Use SQL query logging to identify where multiple unnecessary queries are executed due to unoptimized fetching strategies. Refactor the data access code using techniques like JPQL join fetch, @EntityGraph, or @BatchSize to minimize the number of SQL queries, thus improving overall application performance. Verify the solution with tests. If other redundant (not only n+1) queries executed - fix that too.

Acceptance Criteria:
- The N+1 select problem is identified and reproducible in a real service or controller method.
- SQL logs clearly demonstrate the presence and subsequent elimination of unnecessary queries.
- Entity relationships are optimized using appropriate JPA/Hibernate techniques.
- Tests confirm the correctness of optimized fetching and reduced query count.