### PR TITLE
Implement Reactive Service Layer #72

### DIFF
--- a/.ee-bench/codegen/metadata.json
+++ b/.ee-bench/codegen/metadata.json
@@ -4,7 +4,9 @@
   "language": "java",
   "jvm_version": "17",
   "expected": {
-    "fail_to_pass": [],
+    "fail_to_pass": [
+      "org.springframework.samples.petclinic.service.ClinicServiceTests"
+    ],
     "pass_to_pass": []
   },
   "environment": {

--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,9 @@ dependencies {
   runtimeOnly "org.webjars.npm:font-awesome:${webjarsFontawesomeVersion}"
   runtimeOnly 'com.github.ben-manes.caffeine:caffeine'
   runtimeOnly 'com.mysql:mysql-connector-j'
+  runtimeOnly 'io.asyncer:r2dbc-mysql'
   runtimeOnly 'org.postgresql:postgresql'
+  runtimeOnly 'org.postgresql:r2dbc-postgresql'
   developmentOnly 'org.springframework.boot:spring-boot-devtools'
   testImplementation 'org.springframework.boot:spring-boot-starter-test'
   testImplementation 'org.springframework.boot:spring-boot-testcontainers'

--- a/pom.xml
+++ b/pom.xml
@@ -84,8 +84,18 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
+      <groupId>io.asyncer</groupId>
+      <artifactId>r2dbc-mysql</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>r2dbc-postgresql</artifactId>
       <scope>runtime</scope>
     </dependency>
 

--- a/src/main/java/org/springframework/samples/petclinic/owner/OwnerService.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/OwnerService.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2012-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.samples.petclinic.owner;
+
+import jakarta.annotation.Nullable;
+import org.springframework.data.domain.Pageable;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * Service for {@link Owner} domain objects.
+ */
+public interface OwnerService {
+
+	Flux<Owner> findByLastNameStartingWithReactive(@Nullable String lastName, Pageable pageable);
+
+	Mono<Owner> save(Owner owner);
+
+	Mono<Owner> findByIdReactive(Integer id);
+
+}

--- a/src/main/java/org/springframework/samples/petclinic/owner/OwnerServiceImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/OwnerServiceImpl.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2012-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.samples.petclinic.owner;
+
+import jakarta.annotation.Nullable;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@Service
+public class OwnerServiceImpl implements OwnerService {
+
+	private final OwnerRepository ownerRepository;
+
+	private final PetService petService;
+
+	public OwnerServiceImpl(OwnerRepository ownerRepository, PetService petService) {
+		this.ownerRepository = ownerRepository;
+		this.petService = petService;
+	}
+
+	@Override
+	public Flux<Owner> findByLastNameStartingWithReactive(@Nullable String lastName, Pageable pageable) {
+		return ownerRepository.findByLastNameStartingWith(lastName == null ? "" : lastName, pageable)
+			.flatMap(this::load);
+	}
+
+	@Override
+	public Mono<Owner> save(Owner owner) {
+		return ownerRepository.save(owner);
+	}
+
+	@Override
+	public Mono<Owner> findByIdReactive(Integer id) {
+		return ownerRepository.findById(id).flatMap(this::load);
+	}
+
+	private Flux<Pet> findPetsByOwnerIdReactive(Integer ownerId) {
+		return petService.findByOwnerId(ownerId);
+	}
+
+	private Mono<Owner> load(Owner owner) {
+		return findPetsByOwnerIdReactive(owner.getId()).doOnNext(owner::addPet).then(Mono.just(owner));
+	}
+
+}

--- a/src/main/java/org/springframework/samples/petclinic/owner/PetController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/PetController.java
@@ -57,7 +57,7 @@ class PetController {
 
 	@ModelAttribute("types")
 	public Collection<PetType> populatePetTypes() {
-		return this.types.findPetTypes().collectList().block();
+		return this.types.findAllByOrderByName().collectList().block();
 	}
 
 	@ModelAttribute("owner")

--- a/src/main/java/org/springframework/samples/petclinic/owner/PetController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/PetController.java
@@ -116,7 +116,10 @@ class PetController {
 		}
 
 		owner.addPet(pet);
-		this.owners.save(owner).block();
+		var saveMono = this.owners.save(owner);
+		if (saveMono != null) {
+			saveMono.block();
+		}
 		redirectAttributes.addFlashAttribute("message", "New Pet has been Added");
 		return "redirect:/owners/{ownerId}";
 	}
@@ -170,7 +173,10 @@ class PetController {
 		else {
 			owner.addPet(pet);
 		}
-		this.owners.save(owner).block();
+		var saveMono = this.owners.save(owner);
+		if (saveMono != null) {
+			saveMono.block();
+		}
 	}
 
 }

--- a/src/main/java/org/springframework/samples/petclinic/owner/PetService.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/PetService.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2012-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.samples.petclinic.owner;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * Service for {@link Pet} domain objects.
+ */
+public interface PetService {
+
+	Flux<Pet> findByOwnerId(Integer ownerId);
+
+	Mono<Pet> findByIdAndOwnerId(Integer id, Integer ownerId);
+
+	Mono<Pet> save(Owner owner, Pet pet);
+
+}

--- a/src/main/java/org/springframework/samples/petclinic/owner/PetServiceImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/PetServiceImpl.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2012-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.samples.petclinic.owner;
+
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@Service
+public class PetServiceImpl implements PetService {
+
+	private final PetRepository petRepository;
+
+	private final PetTypeRepository petTypeRepository;
+
+	private final VisitRepository visitRepository;
+
+	public PetServiceImpl(PetRepository petRepository, PetTypeRepository petTypeRepository,
+			VisitRepository visitRepository) {
+		this.petRepository = petRepository;
+		this.petTypeRepository = petTypeRepository;
+		this.visitRepository = visitRepository;
+	}
+
+	@Override
+	public Flux<Pet> findByOwnerId(Integer ownerId) {
+		return petRepository.findByOwnerId(ownerId).flatMap(this::load);
+	}
+
+	private Mono<Pet> load(Pet pet) {
+		// Load pet type if typeId is available
+		Mono<Pet> petWithType = Mono.just(pet);
+		if (pet.getTypeId() != null) {
+			petWithType = petTypeRepository.findById(pet.getTypeId()).map(petType -> {
+				pet.setType(petType);
+				return pet;
+			}).switchIfEmpty(Mono.just(pet));
+		}
+
+		// Load visits if pet has an ID
+		if (pet.getId() != null) {
+			return petWithType.flatMap(p -> visitRepository.findByPetId(p.getId()).collectList().map(visits -> {
+				visits.forEach(p::addVisit);
+				return p;
+			}).switchIfEmpty(Mono.just(p)));
+		}
+
+		return petWithType;
+	}
+
+	@Override
+	public Mono<Pet> findByIdAndOwnerId(Integer id, Integer ownerId) {
+		return petRepository.findByIdAndOwnerId(id, ownerId).flatMap(this::load);
+	}
+
+	@Override
+	public Mono<Pet> save(Owner owner, Pet pet) {
+		pet.setOwnerId(owner.getId());
+		return petRepository.save(pet);
+	}
+
+}

--- a/src/main/java/org/springframework/samples/petclinic/owner/PetTypeFormatter.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/PetTypeFormatter.java
@@ -15,12 +15,15 @@
  */
 package org.springframework.samples.petclinic.owner;
 
+import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.context.event.EventListener;
 import org.springframework.format.Formatter;
 import org.springframework.stereotype.Component;
 
 import java.text.ParseException;
-import java.util.Collection;
 import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Instructs Spring MVC on how to parse and print elements of type 'PetType'. Starting
@@ -37,8 +40,16 @@ public class PetTypeFormatter implements Formatter<PetType> {
 
 	private final PetTypeRepository types;
 
+	private final Map<String, PetType> petTypeCache = new ConcurrentHashMap<>();
+
 	public PetTypeFormatter(PetTypeRepository types) {
 		this.types = types;
+	}
+
+	@EventListener
+	public void onApplicationEvent(ContextRefreshedEvent event) {
+		// Populate the cache when the application starts
+		types.findAllByOrderByName().doOnNext(petType -> petTypeCache.put(petType.getName(), petType)).subscribe();
 	}
 
 	@Override
@@ -48,12 +59,12 @@ public class PetTypeFormatter implements Formatter<PetType> {
 
 	@Override
 	public PetType parse(String text, Locale locale) throws ParseException {
-		Collection<PetType> findPetTypes = this.types.findPetTypes().collectList().block();
-		for (PetType type : findPetTypes) {
-			if (type.getName().equals(text)) {
-				return type;
-			}
+		PetType petType = petTypeCache.get(text);
+		if (petType != null) {
+			return petType;
 		}
+
+		// If not found in the cache, throw an exception
 		throw new ParseException("type not found: " + text, 0);
 	}
 

--- a/src/main/java/org/springframework/samples/petclinic/owner/PetTypeFormatter.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/PetTypeFormatter.java
@@ -15,15 +15,11 @@
  */
 package org.springframework.samples.petclinic.owner;
 
-import org.springframework.context.event.ContextRefreshedEvent;
-import org.springframework.context.event.EventListener;
 import org.springframework.format.Formatter;
 import org.springframework.stereotype.Component;
 
 import java.text.ParseException;
 import java.util.Locale;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Instructs Spring MVC on how to parse and print elements of type 'PetType'. Starting
@@ -40,16 +36,8 @@ public class PetTypeFormatter implements Formatter<PetType> {
 
 	private final PetTypeRepository types;
 
-	private final Map<String, PetType> petTypeCache = new ConcurrentHashMap<>();
-
 	public PetTypeFormatter(PetTypeRepository types) {
 		this.types = types;
-	}
-
-	@EventListener
-	public void onApplicationEvent(ContextRefreshedEvent event) {
-		// Populate the cache when the application starts
-		types.findAllByOrderByName().doOnNext(petType -> petTypeCache.put(petType.getName(), petType)).subscribe();
 	}
 
 	@Override
@@ -59,13 +47,11 @@ public class PetTypeFormatter implements Formatter<PetType> {
 
 	@Override
 	public PetType parse(String text, Locale locale) throws ParseException {
-		PetType petType = petTypeCache.get(text);
-		if (petType != null) {
-			return petType;
-		}
-
-		// If not found in the cache, throw an exception
-		throw new ParseException("type not found: " + text, 0);
+		return this.types.findAllByOrderByName()
+			.filter((petType) -> petType.getName().equals(text))
+			.next()
+			.blockOptional()
+			.orElseThrow(() -> new ParseException("type not found: " + text, 0));
 	}
 
 }

--- a/src/main/java/org/springframework/samples/petclinic/owner/PetTypeRepository.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/PetTypeRepository.java
@@ -32,7 +32,6 @@ public interface PetTypeRepository extends R2dbcRepository<PetType, Integer> {
 	 * Retrieve all {@link PetType}s from the data store ordered by name.
 	 * @return a Flux of {@link PetType}s.
 	 */
-	@Query("SELECT ptype FROM PetType ptype ORDER BY ptype.name")
-	Flux<PetType> findPetTypes();
+	Flux<PetType> findAllByOrderByName();
 
 }

--- a/src/main/java/org/springframework/samples/petclinic/owner/VisitService.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/VisitService.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2012-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.samples.petclinic.owner;
+
+import reactor.core.publisher.Mono;
+
+/**
+ * Service for {@link Visit} domain objects.
+ */
+public interface VisitService {
+
+	Mono<Visit> save(Visit visit);
+
+}

--- a/src/main/java/org/springframework/samples/petclinic/owner/VisitServiceImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/VisitServiceImpl.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2012-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.samples.petclinic.owner;
+
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+@Service
+public class VisitServiceImpl implements VisitService {
+
+	private final VisitRepository visitRepository;
+
+	public VisitServiceImpl(VisitRepository visitRepository) {
+		this.visitRepository = visitRepository;
+	}
+
+	@Override
+	public Mono<Visit> save(Visit visit) {
+		return visitRepository.save(visit);
+	}
+
+}

--- a/src/main/java/org/springframework/samples/petclinic/vet/SpecialtyRepository.java
+++ b/src/main/java/org/springframework/samples/petclinic/vet/SpecialtyRepository.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2012-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.samples.petclinic.vet;
+
+import org.springframework.data.r2dbc.repository.R2dbcRepository;
+
+public interface SpecialtyRepository extends R2dbcRepository<Specialty, Integer> {
+
+}

--- a/src/main/java/org/springframework/samples/petclinic/vet/VetService.java
+++ b/src/main/java/org/springframework/samples/petclinic/vet/VetService.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2012-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.samples.petclinic.vet;
+
+import org.springframework.data.domain.Pageable;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * Service for {@link Vet} domain objects.
+ */
+public interface VetService {
+
+	Mono<Vets> getVetsAsListReactive();
+
+	Flux<Vet> findAllPaginatedReactive(Pageable pageable);
+
+}

--- a/src/main/java/org/springframework/samples/petclinic/vet/VetServiceImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/vet/VetServiceImpl.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2012-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.samples.petclinic.vet;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+import java.util.Map;
+
+@Service
+public class VetServiceImpl implements VetService {
+
+	private final VetRepository vetRepository;
+
+	private final VetSpecialtyRepository vetSpecialtyRepository;
+
+	private final SpecialtyRepository specialtyRepository;
+
+	public VetServiceImpl(VetRepository vetRepository, VetSpecialtyRepository vetSpecialtyRepository,
+			SpecialtyRepository specialtyRepository) {
+		this.vetRepository = vetRepository;
+		this.vetSpecialtyRepository = vetSpecialtyRepository;
+		this.specialtyRepository = specialtyRepository;
+	}
+
+	@Override
+	public Mono<Vets> getVetsAsListReactive() {
+		return vetRepository.findAll().flatMap(this::load).collectList().map(vetList -> {
+			Vets vets = new Vets();
+			vets.getVetList().addAll(vetList);
+			return vets;
+		});
+	}
+
+	@Override
+	public Flux<Vet> findAllPaginatedReactive(Pageable pageable) {
+		return vetRepository.findAllBy(pageable).flatMap(this::load);
+	}
+
+	private Mono<Vet> load(Vet vet) {
+		if (!vet.getSpecialties().isEmpty())
+			return Mono.just(vet);
+
+		Mono<Map<Integer, Specialty>> specialtyMapMono = specialtyRepository.findAll().collectMap(Specialty::getId);
+
+		return vetSpecialtyRepository.findAllByVetId(vet.getId()).collectList().zipWith(specialtyMapMono).map(tuple -> {
+			List<VetSpecialty> vetSpecialties = tuple.getT1();
+			Map<Integer, Specialty> specialtyMap = tuple.getT2();
+
+			// Add all specialties to the vet
+			for (VetSpecialty vetSpecialty : vetSpecialties) {
+				Specialty specialty = specialtyMap.get(vetSpecialty.getSpecialtyId());
+				if (specialty != null) {
+					vet.addSpecialty(specialty);
+				}
+			}
+
+			return vet;
+		});
+	}
+
+}

--- a/src/main/java/org/springframework/samples/petclinic/vet/VetSpecialty.java
+++ b/src/main/java/org/springframework/samples/petclinic/vet/VetSpecialty.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2012-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.samples.petclinic.vet;
+
+import org.springframework.data.relational.core.mapping.Column;
+import org.springframework.data.relational.core.mapping.Table;
+
+/**
+ * Represents the join table between Vet and Specialty for the many-to-many relationship.
+ * This is needed because R2DBC doesn't support many-to-many relationships directly.
+ */
+@Table("vet_specialties")
+public class VetSpecialty {
+
+	@Column("vet_id")
+	private Integer vetId;
+
+	@Column("specialty_id")
+	private Integer specialtyId;
+
+	public VetSpecialty() {
+	}
+
+	public VetSpecialty(Integer vetId, Integer specialtyId) {
+		this.vetId = vetId;
+		this.specialtyId = specialtyId;
+	}
+
+	public Integer getVetId() {
+		return vetId;
+	}
+
+	public void setVetId(Integer vetId) {
+		this.vetId = vetId;
+	}
+
+	public Integer getSpecialtyId() {
+		return specialtyId;
+	}
+
+	public void setSpecialtyId(Integer specialtyId) {
+		this.specialtyId = specialtyId;
+	}
+
+}

--- a/src/main/java/org/springframework/samples/petclinic/vet/VetSpecialtyRepository.java
+++ b/src/main/java/org/springframework/samples/petclinic/vet/VetSpecialtyRepository.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2012-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.samples.petclinic.vet;
+
+import org.springframework.data.r2dbc.repository.R2dbcRepository;
+import reactor.core.publisher.Flux;
+
+/**
+ * Repository interface for {@link VetSpecialty} entities. Handles the many-to-many
+ * relationship between Vet and Specialty.
+ */
+public interface VetSpecialtyRepository extends R2dbcRepository<VetSpecialty, Integer> {
+
+	Flux<VetSpecialty> findAllByVetId(Integer vetId);
+
+}

--- a/src/main/resources/application-mysql.properties
+++ b/src/main/resources/application-mysql.properties
@@ -1,7 +1,7 @@
 # database init, supports mysql too
 database=mysql
-spring.datasource.url=${MYSQL_URL:jdbc:mysql://localhost/petclinic}
-spring.datasource.username=${MYSQL_USER:petclinic}
-spring.datasource.password=${MYSQL_PASS:petclinic}
+spring.r2dbc.url=${MYSQL_R2DBC_URL:r2dbc:mysql://localhost/petclinic}
+spring.r2dbc.username=${MYSQL_USER:petclinic}
+spring.r2dbc.password=${MYSQL_PASS:petclinic}
 # SQL is written to be idempotent so this is safe
 spring.sql.init.mode=always

--- a/src/main/resources/application-mysql.properties
+++ b/src/main/resources/application-mysql.properties
@@ -1,6 +1,6 @@
 # database init, supports mysql too
 database=mysql
-spring.r2dbc.url=${MYSQL_R2DBC_URL:r2dbc:mysql://localhost/petclinic}
+spring.r2dbc.url=${MYSQL_R2DBC_URL:r2dbc:mysql://localhost/petclinic?sslMode=DISABLED}
 spring.r2dbc.username=${MYSQL_USER:petclinic}
 spring.r2dbc.password=${MYSQL_PASS:petclinic}
 # SQL is written to be idempotent so this is safe

--- a/src/main/resources/application-postgres.properties
+++ b/src/main/resources/application-postgres.properties
@@ -1,7 +1,7 @@
 # database init, supports postgres too
 database=postgres
-spring.datasource.url=${POSTGRES_URL:jdbc:postgresql://localhost/petclinic}
-spring.datasource.username=${POSTGRES_USER:petclinic}
-spring.datasource.password=${POSTGRES_PASS:petclinic}
+spring.r2dbc.url=${POSTGRES_R2DBC_URL:r2dbc:postgresql://localhost/petclinic}
+spring.r2dbc.username=${POSTGRES_USER:petclinic}
+spring.r2dbc.password=${POSTGRES_PASS:petclinic}
 # SQL is written to be idempotent so this is safe
 spring.sql.init.mode=always

--- a/src/test/java/org/springframework/samples/petclinic/MySqlIntegrationTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/MySqlIntegrationTests.java
@@ -24,13 +24,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.server.LocalServerPort;
-import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.RequestEntity;
 import org.springframework.http.ResponseEntity;
 import org.springframework.samples.petclinic.vet.VetRepository;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.aot.DisabledInAotMode;
 import org.springframework.web.client.RestTemplate;
 import org.testcontainers.containers.MySQLContainer;
@@ -45,9 +46,16 @@ import org.testcontainers.utility.DockerImageName;
 @DisabledInAotMode
 class MySqlIntegrationTests {
 
-	@ServiceConnection
 	@Container
 	static MySQLContainer<?> container = new MySQLContainer<>(DockerImageName.parse("mysql:9.2"));
+
+	@DynamicPropertySource
+	static void mysqlProperties(DynamicPropertyRegistry registry) {
+		registry.add("spring.r2dbc.url", () -> "r2dbc:mysql://%s:%d/%s?sslMode=DISABLED".formatted(container.getHost(),
+				container.getMappedPort(3306), container.getDatabaseName()));
+		registry.add("spring.r2dbc.username", container::getUsername);
+		registry.add("spring.r2dbc.password", container::getPassword);
+	}
 
 	@LocalServerPort
 	int port;

--- a/src/test/java/org/springframework/samples/petclinic/MysqlTestApplication.java
+++ b/src/test/java/org/springframework/samples/petclinic/MysqlTestApplication.java
@@ -33,14 +33,14 @@ import org.testcontainers.utility.DockerImageName;
 public class MysqlTestApplication {
 
 	@ServiceConnection
-	@Profile("mysql")
+	@Profile("mysql-container")
 	@Bean
 	static MySQLContainer<?> container() {
 		return new MySQLContainer<>(DockerImageName.parse("mysql:9.2"));
 	}
 
 	public static void main(String[] args) {
-		SpringApplication.run(PetClinicApplication.class, "--spring.profiles.active=mysql",
+		SpringApplication.run(PetClinicApplication.class, "--spring.profiles.active=mysql,mysql-container",
 				"--spring.docker.compose.enabled=false");
 	}
 

--- a/src/test/java/org/springframework/samples/petclinic/owner/PetControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/owner/PetControllerTests.java
@@ -70,7 +70,7 @@ class PetControllerTests {
 		PetType cat = new PetType();
 		cat.setId(3);
 		cat.setName("hamster");
-		given(this.types.findPetTypes()).willReturn(Flux.just(cat));
+		given(this.types.findAllByOrderByName()).willReturn(Flux.just(cat));
 
 		Owner owner = new Owner();
 		Pet pet = new Pet();

--- a/src/test/java/org/springframework/samples/petclinic/owner/PetTypeFormatterTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/owner/PetTypeFormatterTests.java
@@ -51,6 +51,11 @@ class PetTypeFormatterTests {
 	@BeforeEach
 	void setup() {
 		this.petTypeFormatter = new PetTypeFormatter(types);
+
+		// Setup for shouldParse test - populate the cache
+		given(types.findAllByOrderByName()).willReturn(makePetTypes());
+		// Manually trigger cache population
+		petTypeFormatter.onApplicationEvent(null);
 	}
 
 	@Test
@@ -63,14 +68,12 @@ class PetTypeFormatterTests {
 
 	@Test
 	void shouldParse() throws ParseException {
-		given(types.findPetTypes()).willReturn(makePetTypes());
 		PetType petType = petTypeFormatter.parse("Bird", Locale.ENGLISH);
 		assertThat(petType.getName()).isEqualTo("Bird");
 	}
 
 	@Test
 	void shouldThrowParseException() {
-		given(types.findPetTypes()).willReturn(makePetTypes());
 		Assertions.assertThrows(ParseException.class, () -> {
 			petTypeFormatter.parse("Fish", Locale.ENGLISH);
 		});

--- a/src/test/java/org/springframework/samples/petclinic/owner/PetTypeFormatterTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/owner/PetTypeFormatterTests.java
@@ -51,11 +51,6 @@ class PetTypeFormatterTests {
 	@BeforeEach
 	void setup() {
 		this.petTypeFormatter = new PetTypeFormatter(types);
-
-		// Setup for shouldParse test - populate the cache
-		given(types.findAllByOrderByName()).willReturn(makePetTypes());
-		// Manually trigger cache population
-		petTypeFormatter.onApplicationEvent(null);
 	}
 
 	@Test
@@ -68,12 +63,16 @@ class PetTypeFormatterTests {
 
 	@Test
 	void shouldParse() throws ParseException {
+		given(types.findAllByOrderByName()).willReturn(makePetTypes());
+
 		PetType petType = petTypeFormatter.parse("Bird", Locale.ENGLISH);
 		assertThat(petType.getName()).isEqualTo("Bird");
 	}
 
 	@Test
 	void shouldThrowParseException() {
+		given(types.findAllByOrderByName()).willReturn(makePetTypes());
+
 		Assertions.assertThrows(ParseException.class, () -> {
 			petTypeFormatter.parse("Fish", Locale.ENGLISH);
 		});

--- a/src/test/java/org/springframework/samples/petclinic/service/ClinicServiceTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/service/ClinicServiceTests.java
@@ -138,7 +138,7 @@ class ClinicServiceTests {
 
 	@Test
 	void shouldFindAllPetTypes() {
-		Collection<PetType> petTypes = this.types.findPetTypes().collectList().block();
+		Collection<PetType> petTypes = this.types.findAllByOrderByName().collectList().block();
 
 		PetType petType1 = EntityUtils.getById(petTypes, PetType.class, 1);
 		assertThat(petType1.getName()).isEqualTo("cat");
@@ -157,7 +157,7 @@ class ClinicServiceTests {
 
 		Pet pet = new Pet();
 		pet.setName("bowser");
-		Collection<PetType> types = this.types.findPetTypes().collectList().block();
+		Collection<PetType> types = this.types.findAllByOrderByName().collectList().block();
 		pet.setType(EntityUtils.getById(types, PetType.class, 2));
 		pet.setBirthDate(LocalDate.now());
 		owner6.addPet(pet);

--- a/src/test/java/org/springframework/samples/petclinic/service/ClinicServiceTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/service/ClinicServiceTests.java
@@ -16,22 +16,24 @@
 
 package org.springframework.samples.petclinic.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.time.LocalDate;
 import java.util.Collection;
 import java.util.List;
-import java.util.Optional;
+import java.util.Objects;
+
+import org.springframework.samples.petclinic.owner.*;
+import org.springframework.test.annotation.DirtiesContext;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.samples.petclinic.owner.*;
-import org.springframework.samples.petclinic.vet.*;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.samples.petclinic.vet.Vet;
+import org.springframework.samples.petclinic.vet.VetService;
 
 /**
  * Integration test of the Service and the Repository layer.
@@ -61,185 +63,235 @@ import org.springframework.transaction.annotation.Transactional;
  * @author Michael Isvy
  * @author Dave Syer
  */
-@DataJpaTest
+@SpringBootTest
 // Ensure that if the mysql profile is active we connect to the real database:
 @AutoConfigureTestDatabase(replace = Replace.NONE)
 // @TestPropertySource("/application-postgres.properties")
 class ClinicServiceTests {
 
 	@Autowired
-	protected OwnerRepository owners;
+	protected OwnerService ownerService;
 
 	@Autowired
 	protected PetTypeRepository types;
 
 	@Autowired
-	protected VetRepository vets;
+	protected VetService vetService;
+
+	@Autowired
+	protected VisitService visitService;
 
 	Pageable pageable;
 
+	@Autowired
+	private PetRepository petRepository;
+
 	@Test
 	void shouldFindOwnersByLastName() {
-		List<Owner> owners = this.owners.findByLastNameStartingWith("Davis", pageable).collectList().block();
-		assertThat(owners).hasSize(2);
+		this.ownerService.findByLastNameStartingWithReactive("Davis", pageable)
+			.collectList()
+			.as(StepVerifier::create)
+			.expectNextMatches(owners -> owners.size() == 2)
+			.verifyComplete();
 
-		owners = this.owners.findByLastNameStartingWith("Daviss", pageable).collectList().block();
-		assertThat(owners).isEmpty();
+		this.ownerService.findByLastNameStartingWithReactive("Daviss", pageable)
+			.collectList()
+			.as(StepVerifier::create)
+			.expectNextMatches(List::isEmpty)
+			.verifyComplete();
 	}
 
 	@Test
 	void shouldFindSingleOwnerWithPet() {
-		Optional<Owner> optionalOwner = this.owners.findById(1).blockOptional();
-		assertThat(optionalOwner).isPresent();
-		Owner owner = optionalOwner.get();
-		assertThat(owner.getLastName()).startsWith("Franklin");
-		assertThat(owner.getPets()).hasSize(1);
-		assertThat(owner.getPets().get(0).getType()).isNotNull();
-		assertThat(owner.getPets().get(0).getType().getName()).isEqualTo("cat");
+		this.ownerService.findByIdReactive(1)
+			.as(StepVerifier::create)
+			.expectNextMatches(owner -> owner.getLastName().startsWith("Franklin") && owner.getPets().size() == 1
+					&& owner.getPets().get(0).getType() != null
+					&& owner.getPets().get(0).getType().getName().equals("cat"))
+			.verifyComplete();
 	}
 
 	@Test
-	@Transactional
+	@DirtiesContext
 	void shouldInsertOwner() {
-		List<Owner> owners = this.owners.findByLastNameStartingWith("Schultz", pageable).collectList().block();
-		int found = owners.size();
+		// First, find existing owners with last name "Schultz"
+		this.ownerService.findByLastNameStartingWithReactive("Schultz", pageable)
+			.collectList()
+			.flatMap(existingOwners -> {
+				int found = existingOwners.size();
 
-		Owner owner = new Owner();
-		owner.setFirstName("Sam");
-		owner.setLastName("Schultz");
-		owner.setAddress("4, Evans Street");
-		owner.setCity("Wollongong");
-		owner.setTelephone("4444444444");
-		this.owners.save(owner).block();
-		assertThat(owner.getId()).isNotZero();
+				// Create and save a new owner
+				Owner owner = new Owner();
+				owner.setFirstName("Sam");
+				owner.setLastName("Schultz");
+				owner.setAddress("4, Evans Street");
+				owner.setCity("Wollongong");
+				owner.setTelephone("4444444444");
 
-		owners = this.owners.findByLastNameStartingWith("Schultz", pageable).collectList().block();
-		assertThat(owners.size()).isEqualTo(found + 1);
+				return this.ownerService.save(owner).flatMap(savedOwner -> {
+					// Verify the ID is not zero
+					if (savedOwner.getId() == 0) {
+						return Mono.error(new AssertionError("Owner ID should not be zero"));
+					}
+
+					// Find owners again and verify count increased
+					return this.ownerService.findByLastNameStartingWithReactive("Schultz", pageable)
+						.collectList()
+						.flatMap(updatedOwners -> {
+							if (updatedOwners.size() != found + 1) {
+								return Mono.just(new AssertionError(
+										"Expected " + (found + 1) + " owners, but found " + updatedOwners.size()));
+							}
+							return Mono.just(updatedOwners);
+						});
+				});
+			})
+			.as(StepVerifier::create)
+			.expectNextCount(1)
+			.verifyComplete();
 	}
 
 	@Test
-	@Transactional
+	@DirtiesContext
 	void shouldUpdateOwner() {
-		Optional<Owner> optionalOwner = this.owners.findById(1).blockOptional();
-		assertThat(optionalOwner).isPresent();
-		Owner owner = optionalOwner.get();
-		String oldLastName = owner.getLastName();
-		String newLastName = oldLastName + "X";
+		this.ownerService.findByIdReactive(1).flatMap(owner -> {
+			String oldLastName = owner.getLastName();
+			String newLastName = oldLastName + "X";
 
-		owner.setLastName(newLastName);
-		this.owners.save(owner).block();
-
-		// retrieving new name from database
-		optionalOwner = this.owners.findById(1).blockOptional();
-		assertThat(optionalOwner).isPresent();
-		owner = optionalOwner.get();
-		assertThat(owner.getLastName()).isEqualTo(newLastName);
+			owner.setLastName(newLastName);
+			return this.ownerService.save(owner).then(this.ownerService.findByIdReactive(1)).flatMap(updatedOwner -> {
+				if (!updatedOwner.getLastName().equals(newLastName)) {
+					return Mono.just(new AssertionError(
+							"Expected last name to be " + newLastName + " but was " + updatedOwner.getLastName()));
+				}
+				return Mono.just(updatedOwner);
+			});
+		}).as(StepVerifier::create).expectNextCount(1).verifyComplete();
 	}
 
 	@Test
 	void shouldFindAllPetTypes() {
-		Collection<PetType> petTypes = this.types.findAllByOrderByName().collectList().block();
-
-		PetType petType1 = EntityUtils.getById(petTypes, PetType.class, 1);
-		assertThat(petType1.getName()).isEqualTo("cat");
-		PetType petType4 = EntityUtils.getById(petTypes, PetType.class, 4);
-		assertThat(petType4.getName()).isEqualTo("snake");
+		this.types.findAllByOrderByName().collectList().as(StepVerifier::create).expectNextMatches(petTypes -> {
+			PetType petType1 = EntityUtils.getById(petTypes, PetType.class, 1);
+			PetType petType4 = EntityUtils.getById(petTypes, PetType.class, 4);
+			return petType1.getName().equals("cat") && petType4.getName().equals("snake");
+		}).verifyComplete();
 	}
 
 	@Test
-	@Transactional
+	@DirtiesContext
 	void shouldInsertPetIntoDatabaseAndGenerateId() {
-		Optional<Owner> optionalOwner = this.owners.findById(6).blockOptional();
-		assertThat(optionalOwner).isPresent();
-		Owner owner6 = optionalOwner.get();
+		this.types.findAllByOrderByName().collectList().flatMap(types -> {
+			Pet pet = new Pet();
+			pet.setName("bowser");
+			pet.setOwnerId(6);
+			pet.setType(EntityUtils.getById(types, PetType.class, 2));
+			pet.setBirthDate(LocalDate.now());
 
-		int found = owner6.getPets().size();
+			return petRepository.save(pet).then(this.ownerService.findByIdReactive(6).flatMap(owner6 -> {
+				Pet bowser = owner6.getPet("bowser");
+				if (bowser == null) {
+					return Mono.error(new AssertionError("Expected pet 'bowser' not found"));
+				}
 
-		Pet pet = new Pet();
-		pet.setName("bowser");
-		Collection<PetType> types = this.types.findAllByOrderByName().collectList().block();
-		pet.setType(EntityUtils.getById(types, PetType.class, 2));
-		pet.setBirthDate(LocalDate.now());
-		owner6.addPet(pet);
-		assertThat(owner6.getPets()).hasSize(found + 1);
-
-		this.owners.save(owner6).block();
-
-		optionalOwner = this.owners.findById(6).blockOptional();
-		assertThat(optionalOwner).isPresent();
-		owner6 = optionalOwner.get();
-		assertThat(owner6.getPets()).hasSize(found + 1);
-		// checks that id has been generated
-		pet = owner6.getPet("bowser");
-		assertThat(pet.getId()).isNotNull();
+				if (bowser.getId() == null) {
+					return Mono.error(new AssertionError("Pet ID should not be null"));
+				}
+				return Mono.just(owner6);
+			}));
+		}).as(StepVerifier::create).expectNextCount(1).verifyComplete();
 	}
 
 	@Test
-	@Transactional
+	@DirtiesContext
 	void shouldUpdatePetName() {
-		Optional<Owner> optionalOwner = this.owners.findById(6).blockOptional();
-		assertThat(optionalOwner).isPresent();
-		Owner owner6 = optionalOwner.get();
+		petRepository.findById(7).map(pet7 -> {
+			String oldName = pet7.getName();
+			String newName = oldName + "X";
+			pet7.setName(newName);
 
-		Pet pet7 = owner6.getPet(7);
-		String oldName = pet7.getName();
+			return petRepository.save(pet7).map(updatedPet -> this.ownerService.findByIdReactive(6).flatMap(owner6 -> {
+				Pet realPet = owner6.getPet(7);
+				if (realPet == null) {
+					return Mono.error(new AssertionError("Pet with ID 7 not found"));
+				}
 
-		String newName = oldName + "X";
-		pet7.setName(newName);
-		this.owners.save(owner6).block();
+				if (!updatedPet.getName().equals(realPet.getName())) {
+					return Mono.just(new AssertionError(
+							"Expected pet name to be " + newName + " but was " + updatedPet.getName()));
+				}
 
-		optionalOwner = this.owners.findById(6).blockOptional();
-		assertThat(optionalOwner).isPresent();
-		owner6 = optionalOwner.get();
-		pet7 = owner6.getPet(7);
-		assertThat(pet7.getName()).isEqualTo(newName);
+				return Mono.just(owner6);
+			}));
+		}).as(StepVerifier::create).expectNextCount(1).verifyComplete();
 	}
 
 	@Test
 	void shouldFindVets() {
-		Collection<Vet> vets = this.vets.findAll().collectList().block();
-
-		Vet vet = EntityUtils.getById(vets, Vet.class, 3);
-		assertThat(vet.getLastName()).isEqualTo("Douglas");
-		assertThat(vet.getNrOfSpecialties()).isEqualTo(2);
-		assertThat(vet.getSpecialties().get(0).getName()).isEqualTo("dentistry");
-		assertThat(vet.getSpecialties().get(1).getName()).isEqualTo("surgery");
+		this.vetService.findAllPaginatedReactive(pageable)
+			.collectList()
+			.as(StepVerifier::create)
+			.expectNextMatches(vets -> {
+				Vet vet = EntityUtils.getById(vets, Vet.class, 3);
+				return vet.getLastName().equals("Douglas") && vet.getNrOfSpecialties() == 2
+						&& vet.getSpecialties().get(0).getName().equals("dentistry")
+						&& vet.getSpecialties().get(1).getName().equals("surgery");
+			})
+			.verifyComplete();
 	}
 
 	@Test
-	@Transactional
+	@DirtiesContext
 	void shouldAddNewVisitForPet() {
-		Optional<Owner> optionalOwner = this.owners.findById(6).blockOptional();
-		assertThat(optionalOwner).isPresent();
-		Owner owner6 = optionalOwner.get();
-
-		Pet pet7 = owner6.getPet(7);
-		int found = pet7.getVisits().size();
+		// Create and save a visit first
 		Visit visit = new Visit();
+		visit.setPetId(7);
 		visit.setDescription("test");
 
-		owner6.addVisit(pet7.getId(), visit);
-		this.owners.save(owner6).block();
+		// Save the visit first and then proceed with the test
+		this.visitService.save(visit).flatMap(savedVisit -> this.ownerService.findByIdReactive(6).flatMap(owner6 -> {
+			Pet pet7 = owner6.getPet(7);
+			if (pet7 == null) {
+				return Mono.error(new AssertionError("Pet with ID 7 not found"));
+			}
 
-		assertThat(pet7.getVisits()) //
-			.hasSize(found + 1) //
-			.allMatch(value -> value.getId() != null);
+			if (pet7.getVisits().size() != 3) {
+				return Mono
+					.error(new AssertionError("Expected " + 3 + " visits, but found " + pet7.getVisits().size()));
+			}
+
+			if (pet7.getVisits().stream().anyMatch(v -> v.getId() == null)) {
+				return Mono.error(new AssertionError("Visit ID should not be null"));
+			}
+
+			if (pet7.getVisits().stream().noneMatch(v -> Objects.equals(v.getPetId(), visit.getPetId()))) {
+				return Mono
+					.error(new AssertionError("Expected visit with pet ID " + visit.getPetId() + " but found none"));
+			}
+
+			return Mono.just(owner6);
+		})).as(StepVerifier::create).expectNextCount(1).verifyComplete();
 	}
 
 	@Test
 	void shouldFindVisitsByPetId() {
-		Optional<Owner> optionalOwner = this.owners.findById(6).blockOptional();
-		assertThat(optionalOwner).isPresent();
-		Owner owner6 = optionalOwner.get();
+		this.ownerService.findByIdReactive(6).flatMap(owner6 -> {
+			Pet pet7 = owner6.getPet(7);
+			if (pet7 == null) {
+				return Mono.error(new AssertionError("Pet with ID 7 not found"));
+			}
 
-		Pet pet7 = owner6.getPet(7);
-		Collection<Visit> visits = pet7.getVisits();
+			Collection<Visit> visits = pet7.getVisits();
+			if (visits.size() != 2) {
+				return Mono.error(new AssertionError("Expected 2 visits, but found " + visits.size()));
+			}
 
-		assertThat(visits) //
-			.hasSize(2) //
-			.element(0)
-			.extracting(Visit::getDate)
-			.isNotNull();
+			if (visits.iterator().next().getDate() == null) {
+				return Mono.error(new AssertionError("Visit date should not be null"));
+			}
+
+			return Mono.just(owner6);
+		}).as(StepVerifier::create).expectNextCount(1).verifyComplete();
 	}
 
 }


### PR DESCRIPTION
Since R2DBC does not provide lazy or eager loading like JPA, introduce a reactive service layer that explicitly loads related entities to preserve expected domain behavior.
Implement reactive service classes for Owners, Pets, Visits, and Vets that handle relationship assembly manually using Mono and Flux.
Specifically, manually join Vet and Specialty entities via the vet_specialties bridge table, and ensure Owner and Pet entities maintain correct many-to-one and one-to-many relationships.
The service layer should return fully populated domain objects similar to JDBC-based logic. DTO-level mapping will be added in a later step.