### PR TITLE
Transactional Reactive services #73

### DIFF
--- a/.ee-bench/codegen/metadata.json
+++ b/.ee-bench/codegen/metadata.json
@@ -4,7 +4,9 @@
   "language": "java",
   "jvm_version": "17",
   "expected": {
-    "fail_to_pass": [],
+    "fail_to_pass": [
+      "org.springframework.samples.petclinic.owner.OwnerServiceTransactionTest"
+    ],
     "pass_to_pass": []
   },
   "environment": {

--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,8 @@ dependencies {
   testImplementation 'io.projectreactor:reactor-test'
   testImplementation 'org.testcontainers:db2'
   runtimeOnly 'io.r2dbc:r2dbc-h2'
+  runtimeOnly 'io.asyncer:r2dbc-mysql'
+  runtimeOnly 'org.postgresql:r2dbc-postgresql'
   runtimeOnly 'org.springframework.boot:spring-boot-starter-actuator'
   runtimeOnly "org.webjars:webjars-locator-lite:${webjarsLocatorLiteVersion}"
   runtimeOnly "org.webjars.npm:bootstrap:${webjarsBootstrapVersion}"

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,16 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
+      <groupId>io.asyncer</groupId>
+      <artifactId>r2dbc-mysql</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>r2dbc-postgresql</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
       <groupId>com.mysql</groupId>
       <artifactId>mysql-connector-j</artifactId>
       <scope>runtime</scope>

--- a/src/main/java/org/springframework/samples/petclinic/owner/OwnerServiceImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/OwnerServiceImpl.java
@@ -18,10 +18,12 @@ package org.springframework.samples.petclinic.owner;
 import jakarta.annotation.Nullable;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 @Service
+@Transactional(readOnly = true)
 public class OwnerServiceImpl implements OwnerService {
 
 	private final OwnerRepository ownerRepository;
@@ -40,6 +42,7 @@ public class OwnerServiceImpl implements OwnerService {
 	}
 
 	@Override
+	@Transactional
 	public Mono<Owner> save(Owner owner) {
 		return ownerRepository.save(owner);
 	}

--- a/src/main/java/org/springframework/samples/petclinic/owner/PetServiceImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/PetServiceImpl.java
@@ -16,10 +16,12 @@
 package org.springframework.samples.petclinic.owner;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 @Service
+@Transactional(readOnly = true)
 public class PetServiceImpl implements PetService {
 
 	private final PetRepository petRepository;
@@ -67,6 +69,7 @@ public class PetServiceImpl implements PetService {
 	}
 
 	@Override
+	@Transactional
 	public Mono<Pet> save(Owner owner, Pet pet) {
 		pet.setOwnerId(owner.getId());
 		return petRepository.save(pet);

--- a/src/main/java/org/springframework/samples/petclinic/owner/VisitServiceImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/VisitServiceImpl.java
@@ -16,9 +16,11 @@
 package org.springframework.samples.petclinic.owner;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import reactor.core.publisher.Mono;
 
 @Service
+@Transactional(readOnly = true)
 public class VisitServiceImpl implements VisitService {
 
 	private final VisitRepository visitRepository;
@@ -28,6 +30,7 @@ public class VisitServiceImpl implements VisitService {
 	}
 
 	@Override
+	@Transactional
 	public Mono<Visit> save(Visit visit) {
 		return visitRepository.save(visit);
 	}

--- a/src/main/java/org/springframework/samples/petclinic/vet/VetServiceImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/vet/VetServiceImpl.java
@@ -17,6 +17,7 @@ package org.springframework.samples.petclinic.vet;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -24,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 
 @Service
+@Transactional(readOnly = true)
 public class VetServiceImpl implements VetService {
 
 	private final VetRepository vetRepository;

--- a/src/main/resources/application-mysql.properties
+++ b/src/main/resources/application-mysql.properties
@@ -1,7 +1,7 @@
 # database init, supports mysql too
 database=mysql
-spring.datasource.url=${MYSQL_URL:jdbc:mysql://localhost/petclinic}
-spring.datasource.username=${MYSQL_USER:petclinic}
-spring.datasource.password=${MYSQL_PASS:petclinic}
+spring.r2dbc.url=${MYSQL_R2DBC_URL:r2dbc:mysql://localhost/petclinic?sslMode=DISABLED}
+spring.r2dbc.username=${MYSQL_USER:petclinic}
+spring.r2dbc.password=${MYSQL_PASS:petclinic}
 # SQL is written to be idempotent so this is safe
 spring.sql.init.mode=always

--- a/src/test/java/org/springframework/samples/petclinic/MySqlIntegrationTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/MySqlIntegrationTests.java
@@ -24,13 +24,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.server.LocalServerPort;
-import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.RequestEntity;
 import org.springframework.http.ResponseEntity;
 import org.springframework.samples.petclinic.vet.VetRepository;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.aot.DisabledInAotMode;
 import org.springframework.web.client.RestTemplate;
 import org.testcontainers.containers.MySQLContainer;
@@ -45,9 +46,16 @@ import org.testcontainers.utility.DockerImageName;
 @DisabledInAotMode
 class MySqlIntegrationTests {
 
-	@ServiceConnection
 	@Container
 	static MySQLContainer<?> container = new MySQLContainer<>(DockerImageName.parse("mysql:9.2"));
+
+	@DynamicPropertySource
+	static void mysqlProperties(DynamicPropertyRegistry registry) {
+		registry.add("spring.r2dbc.url", () -> "r2dbc:mysql://%s:%d/%s?sslMode=DISABLED".formatted(container.getHost(),
+				container.getMappedPort(3306), container.getDatabaseName()));
+		registry.add("spring.r2dbc.username", container::getUsername);
+		registry.add("spring.r2dbc.password", container::getPassword);
+	}
 
 	@LocalServerPort
 	int port;

--- a/src/test/java/org/springframework/samples/petclinic/MysqlTestApplication.java
+++ b/src/test/java/org/springframework/samples/petclinic/MysqlTestApplication.java
@@ -33,14 +33,14 @@ import org.testcontainers.utility.DockerImageName;
 public class MysqlTestApplication {
 
 	@ServiceConnection
-	@Profile("mysql")
+	@Profile("mysql-container")
 	@Bean
 	static MySQLContainer<?> container() {
 		return new MySQLContainer<>(DockerImageName.parse("mysql:9.2"));
 	}
 
 	public static void main(String[] args) {
-		SpringApplication.run(PetClinicApplication.class, "--spring.profiles.active=mysql",
+		SpringApplication.run(PetClinicApplication.class, "--spring.profiles.active=mysql,mysql-container",
 				"--spring.docker.compose.enabled=false");
 	}
 

--- a/src/test/java/org/springframework/samples/petclinic/owner/OwnerServiceTransactionTest.java
+++ b/src/test/java/org/springframework/samples/petclinic/owner/OwnerServiceTransactionTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2012-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.samples.petclinic.owner;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.samples.petclinic.system.TestTransactionConfig;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Import(TestTransactionConfig.class)
+@SpringBootTest
+public class OwnerServiceTransactionTest {
+
+	@Autowired
+	OwnerService ownerService;
+
+	@Autowired
+	TestTransactionConfig transactionConfig;
+
+	@Test
+	public void shouldStartTransaction() {
+		var owner = ownerService.findByIdReactive(1).block();
+		ownerService.save(owner).block();
+
+		assertEquals(3, transactionConfig.getCount());
+	}
+
+}

--- a/src/test/java/org/springframework/samples/petclinic/owner/PetControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/owner/PetControllerTests.java
@@ -22,8 +22,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledInNativeImage;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.aot.DisabledInAotMode;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -34,6 +37,7 @@ import java.time.LocalDate;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
@@ -48,6 +52,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  */
 @WebMvcTest(value = PetController.class,
 		includeFilters = @ComponentScan.Filter(value = PetTypeFormatter.class, type = FilterType.ASSIGNABLE_TYPE))
+@Import(PetControllerTests.PetTypeRepositoryTestConfig.class)
 @DisabledInNativeImage
 @DisabledInAotMode
 class PetControllerTests {
@@ -62,15 +67,12 @@ class PetControllerTests {
 	@MockitoBean
 	private OwnerRepository owners;
 
-	@MockitoBean
+	@Autowired
 	private PetTypeRepository types;
 
 	@BeforeEach
 	void setup() {
-		PetType cat = new PetType();
-		cat.setId(3);
-		cat.setName("hamster");
-		given(this.types.findAllByOrderByName()).willReturn(Flux.just(cat));
+		given(this.types.findAllByOrderByName()).willReturn(Flux.just(hamster()));
 
 		Owner owner = new Owner();
 		Pet pet = new Pet();
@@ -82,6 +84,13 @@ class PetControllerTests {
 		pet.setName("petty");
 		dog.setName("doggy");
 		given(this.owners.findById(TEST_OWNER_ID)).willReturn(Mono.just(owner));
+	}
+
+	private static PetType hamster() {
+		PetType hamster = new PetType();
+		hamster.setId(3);
+		hamster.setName("hamster");
+		return hamster;
 	}
 
 	@Test
@@ -213,6 +222,18 @@ class PetControllerTests {
 				.andExpect(model().attributeHasFieldErrors("pet", "name"))
 				.andExpect(model().attributeHasFieldErrorCode("pet", "name", "required"))
 				.andExpect(view().name("pets/createOrUpdatePetForm"));
+		}
+
+	}
+
+	@TestConfiguration
+	static class PetTypeRepositoryTestConfig {
+
+		@Bean
+		PetTypeRepository types() {
+			PetTypeRepository types = mock(PetTypeRepository.class);
+			given(types.findAllByOrderByName()).willReturn(Flux.just(hamster()));
+			return types;
 		}
 
 	}

--- a/src/test/java/org/springframework/samples/petclinic/system/TestTransactionConfig.java
+++ b/src/test/java/org/springframework/samples/petclinic/system/TestTransactionConfig.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2012-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.samples.petclinic.system;
+
+import org.jetbrains.annotations.NotNull;
+import org.springframework.context.annotation.Bean;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.transaction.ReactiveTransaction;
+import org.springframework.transaction.ReactiveTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import reactor.core.publisher.Mono;
+
+@TestConfiguration
+public class TestTransactionConfig {
+
+	public Integer getCount() {
+		return count;
+	}
+
+	private Integer count = 0;
+
+	@Bean
+	public ReactiveTransactionManager reactiveTransactionManager() {
+		return new TestTransactionManager();
+	}
+
+	public class TestTransactionManager implements ReactiveTransactionManager {
+
+		@Override
+		public @NotNull Mono<ReactiveTransaction> getReactiveTransaction(TransactionDefinition definition) {
+			count++;
+			return Mono.just(new TestTransactionManager.DummyReactiveTransaction());
+		}
+
+		@Override
+		public @NotNull Mono<Void> commit(@NotNull ReactiveTransaction transaction) {
+			return Mono.empty();
+		}
+
+		@Override
+		public @NotNull Mono<Void> rollback(@NotNull ReactiveTransaction transaction) {
+			return Mono.empty();
+		}
+
+		private static class DummyReactiveTransaction implements ReactiveTransaction {
+
+			@Override
+			public void setRollbackOnly() {
+			}
+
+		}
+
+	}
+
+}


### PR DESCRIPTION
Add transactional boundaries to the reactive service layer to ensure that database operations executed within reactive flows are properly wrapped in Spring-managed transactions.
Annotate service classes and their mutating methods with @Transactional to enable transaction start and commit behavior.