### PR TITLE
Reactive Exception Handling #75

### DIFF
--- a/.ee-bench/codegen/metadata.json
+++ b/.ee-bench/codegen/metadata.json
@@ -4,7 +4,9 @@
   "language": "java",
   "jvm_version": "17",
   "expected": {
-    "fail_to_pass": [],
+    "fail_to_pass": [
+      "org.springframework.samples.petclinic.system.CrashControllerIntegrationTests"
+    ],
     "pass_to_pass": []
   },
   "environment": {

--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,8 @@ dependencies {
   runtimeOnly "org.webjars.npm:bootstrap:${webjarsBootstrapVersion}"
   runtimeOnly "org.webjars.npm:font-awesome:${webjarsFontawesomeVersion}"
   runtimeOnly 'com.github.ben-manes.caffeine:caffeine'
+  runtimeOnly 'io.asyncer:r2dbc-mysql'
+  runtimeOnly 'org.postgresql:r2dbc-postgresql'
   runtimeOnly 'com.mysql:mysql-connector-j'
   runtimeOnly 'org.postgresql:postgresql'
   developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,16 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
+      <groupId>io.asyncer</groupId>
+      <artifactId>r2dbc-mysql</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>r2dbc-postgresql</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
       <groupId>com.mysql</groupId>
       <artifactId>mysql-connector-j</artifactId>
       <scope>runtime</scope>

--- a/src/main/java/org/springframework/samples/petclinic/system/GlobalErrorHandler.java
+++ b/src/main/java/org/springframework/samples/petclinic/system/GlobalErrorHandler.java
@@ -15,24 +15,19 @@
  */
 package org.springframework.samples.petclinic.system;
 
-import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.GetMapping;
 import reactor.core.publisher.Mono;
 
-/**
- * Controller used to showcase what happens when an exception is thrown
- *
- * @author Michael Isvy
- * <p/>
- * Also see how a view that resolves to "error" has been added ("error.html").
- */
-@Controller
-class CrashController {
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 
-	@GetMapping("/oups")
-	public Mono<String> triggerException() {
-		return Mono.error(new RuntimeException(
-				"Expected: controller used to showcase what " + "happens when an exception is thrown"));
+@ControllerAdvice
+public class GlobalErrorHandler {
+
+	@ExceptionHandler(RuntimeException.class)
+	public Mono<String> handleRuntimeException(RuntimeException ex, Model model) {
+		model.addAttribute("message", ex.getMessage());
+		return Mono.just("error");
 	}
 
 }

--- a/src/main/resources/application-mysql.properties
+++ b/src/main/resources/application-mysql.properties
@@ -3,8 +3,5 @@ database=mysql
 spring.r2dbc.url=${MYSQL_R2DBC_URL:r2dbc:mysql://localhost/petclinic}
 spring.r2dbc.username=${MYSQL_USER:petclinic}
 spring.r2dbc.password=${MYSQL_PASS:petclinic}
-spring.datasource.url=${MYSQL_URL:jdbc:mysql://localhost/petclinic}
-spring.datasource.username=${MYSQL_USER:petclinic}
-spring.datasource.password=${MYSQL_PASS:petclinic}
 # SQL is written to be idempotent so this is safe
 spring.sql.init.mode=always

--- a/src/main/resources/application-mysql.properties
+++ b/src/main/resources/application-mysql.properties
@@ -1,5 +1,8 @@
 # database init, supports mysql too
 database=mysql
+spring.r2dbc.url=${MYSQL_R2DBC_URL:r2dbc:mysql://localhost/petclinic}
+spring.r2dbc.username=${MYSQL_USER:petclinic}
+spring.r2dbc.password=${MYSQL_PASS:petclinic}
 spring.datasource.url=${MYSQL_URL:jdbc:mysql://localhost/petclinic}
 spring.datasource.username=${MYSQL_USER:petclinic}
 spring.datasource.password=${MYSQL_PASS:petclinic}

--- a/src/main/resources/application-mysql.properties
+++ b/src/main/resources/application-mysql.properties
@@ -1,6 +1,6 @@
 # database init, supports mysql too
 database=mysql
-spring.r2dbc.url=${MYSQL_R2DBC_URL:r2dbc:mysql://localhost/petclinic}
+spring.r2dbc.url=${MYSQL_R2DBC_URL:r2dbc:mysql://localhost/petclinic?sslMode=DISABLED}
 spring.r2dbc.username=${MYSQL_USER:petclinic}
 spring.r2dbc.password=${MYSQL_PASS:petclinic}
 # SQL is written to be idempotent so this is safe

--- a/src/main/resources/application-postgres.properties
+++ b/src/main/resources/application-postgres.properties
@@ -1,5 +1,8 @@
 # database init, supports postgres too
 database=postgres
+spring.r2dbc.url=${POSTGRES_R2DBC_URL:r2dbc:postgresql://localhost/petclinic}
+spring.r2dbc.username=${POSTGRES_USER:petclinic}
+spring.r2dbc.password=${POSTGRES_PASS:petclinic}
 spring.datasource.url=${POSTGRES_URL:jdbc:postgresql://localhost/petclinic}
 spring.datasource.username=${POSTGRES_USER:petclinic}
 spring.datasource.password=${POSTGRES_PASS:petclinic}

--- a/src/main/resources/application-postgres.properties
+++ b/src/main/resources/application-postgres.properties
@@ -3,8 +3,5 @@ database=postgres
 spring.r2dbc.url=${POSTGRES_R2DBC_URL:r2dbc:postgresql://localhost/petclinic}
 spring.r2dbc.username=${POSTGRES_USER:petclinic}
 spring.r2dbc.password=${POSTGRES_PASS:petclinic}
-spring.datasource.url=${POSTGRES_URL:jdbc:postgresql://localhost/petclinic}
-spring.datasource.username=${POSTGRES_USER:petclinic}
-spring.datasource.password=${POSTGRES_PASS:petclinic}
 # SQL is written to be idempotent so this is safe
 spring.sql.init.mode=always

--- a/src/test/java/org/springframework/samples/petclinic/MySqlIntegrationTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/MySqlIntegrationTests.java
@@ -21,7 +21,6 @@ import org.junit.jupiter.api.condition.DisabledInNativeImage;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
-import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.http.MediaType;
 import org.springframework.samples.petclinic.vet.VetRepository;
 import org.springframework.test.context.ActiveProfiles;
@@ -41,13 +40,12 @@ import org.testcontainers.utility.DockerImageName;
 @DisabledInAotMode
 class MySqlIntegrationTests {
 
-	@ServiceConnection
 	@Container
 	static MySQLContainer<?> container = new MySQLContainer<>(DockerImageName.parse("mysql:9.2"));
 
 	@DynamicPropertySource
 	static void mysqlProperties(DynamicPropertyRegistry registry) {
-		registry.add("spring.r2dbc.url", () -> "r2dbc:mysql://%s:%d/%s".formatted(container.getHost(),
+		registry.add("spring.r2dbc.url", () -> "r2dbc:mysql://%s:%d/%s?sslMode=DISABLED".formatted(container.getHost(),
 				container.getMappedPort(3306), container.getDatabaseName()));
 		registry.add("spring.r2dbc.username", container::getUsername);
 		registry.add("spring.r2dbc.password", container::getPassword);

--- a/src/test/java/org/springframework/samples/petclinic/MySqlIntegrationTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/MySqlIntegrationTests.java
@@ -26,6 +26,8 @@ import org.springframework.http.MediaType;
 import org.springframework.samples.petclinic.vet.VetRepository;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.aot.DisabledInAotMode;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.junit.jupiter.Container;
@@ -42,6 +44,14 @@ class MySqlIntegrationTests {
 	@ServiceConnection
 	@Container
 	static MySQLContainer<?> container = new MySQLContainer<>(DockerImageName.parse("mysql:9.2"));
+
+	@DynamicPropertySource
+	static void mysqlProperties(DynamicPropertyRegistry registry) {
+		registry.add("spring.r2dbc.url", () -> "r2dbc:mysql://%s:%d/%s".formatted(container.getHost(),
+				container.getMappedPort(3306), container.getDatabaseName()));
+		registry.add("spring.r2dbc.username", container::getUsername);
+		registry.add("spring.r2dbc.password", container::getPassword);
+	}
 
 	@Autowired
 	private VetRepository vets;

--- a/src/test/java/org/springframework/samples/petclinic/MySqlIntegrationTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/MySqlIntegrationTests.java
@@ -16,23 +16,17 @@
 
 package org.springframework.samples.petclinic;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledInNativeImage;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
-import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
-import org.springframework.boot.web.client.RestTemplateBuilder;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.RequestEntity;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.MediaType;
 import org.springframework.samples.petclinic.vet.VetRepository;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.aot.DisabledInAotMode;
-import org.springframework.web.client.RestTemplate;
+import org.springframework.test.web.reactive.server.WebTestClient;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -49,14 +43,11 @@ class MySqlIntegrationTests {
 	@Container
 	static MySQLContainer<?> container = new MySQLContainer<>(DockerImageName.parse("mysql:9.2"));
 
-	@LocalServerPort
-	int port;
-
 	@Autowired
 	private VetRepository vets;
 
 	@Autowired
-	private RestTemplateBuilder builder;
+	private WebTestClient webTestClient;
 
 	@Test
 	void testFindAll() {
@@ -66,9 +57,13 @@ class MySqlIntegrationTests {
 
 	@Test
 	void testOwnerDetails() {
-		RestTemplate template = builder.rootUri("http://localhost:" + port).build();
-		ResponseEntity<String> result = template.exchange(RequestEntity.get("/owners/1").build(), String.class);
-		assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+		webTestClient.get()
+			.uri("/owners/1")
+			.exchange()
+			.expectStatus()
+			.isOk()
+			.expectHeader()
+			.contentTypeCompatibleWith(MediaType.TEXT_HTML);
 	}
 
 }

--- a/src/test/java/org/springframework/samples/petclinic/MysqlTestApplication.java
+++ b/src/test/java/org/springframework/samples/petclinic/MysqlTestApplication.java
@@ -33,14 +33,14 @@ import org.testcontainers.utility.DockerImageName;
 public class MysqlTestApplication {
 
 	@ServiceConnection
-	@Profile("mysql")
+	@Profile("mysql-container")
 	@Bean
 	static MySQLContainer<?> container() {
 		return new MySQLContainer<>(DockerImageName.parse("mysql:9.2"));
 	}
 
 	public static void main(String[] args) {
-		SpringApplication.run(PetClinicApplication.class, "--spring.profiles.active=mysql",
+		SpringApplication.run(PetClinicApplication.class, "--spring.profiles.active=mysql,mysql-container",
 				"--spring.docker.compose.enabled=false");
 	}
 

--- a/src/test/java/org/springframework/samples/petclinic/PostgresIntegrationTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/PostgresIntegrationTests.java
@@ -16,7 +16,6 @@
 
 package org.springframework.samples.petclinic;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
@@ -34,18 +33,14 @@ import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.boot.context.event.ApplicationPreparedEvent;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
-import org.springframework.boot.test.web.server.LocalServerPort;
-import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.ApplicationListener;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.EnumerablePropertySource;
 import org.springframework.core.env.PropertySource;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.RequestEntity;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.MediaType;
 import org.springframework.samples.petclinic.vet.VetRepository;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.web.client.RestTemplate;
+import org.springframework.test.web.reactive.server.WebTestClient;
 import org.testcontainers.DockerClientFactory;
 
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT, properties = { "spring.docker.compose.skip.in-tests=false", //
@@ -54,14 +49,11 @@ import org.testcontainers.DockerClientFactory;
 @DisabledInNativeImage
 public class PostgresIntegrationTests {
 
-	@LocalServerPort
-	int port;
-
 	@Autowired
 	private VetRepository vets;
 
 	@Autowired
-	private RestTemplateBuilder builder;
+	private WebTestClient webTestClient;
 
 	@BeforeAll
 	static void available() {
@@ -86,9 +78,13 @@ public class PostgresIntegrationTests {
 
 	@Test
 	void testOwnerDetails() {
-		RestTemplate template = builder.rootUri("http://localhost:" + port).build();
-		ResponseEntity<String> result = template.exchange(RequestEntity.get("/owners/1").build(), String.class);
-		assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+		webTestClient.get()
+			.uri("/owners/1")
+			.exchange()
+			.expectStatus()
+			.isOk()
+			.expectHeader()
+			.contentTypeCompatibleWith(MediaType.TEXT_HTML);
 	}
 
 	static class PropertiesLogger implements ApplicationListener<ApplicationPreparedEvent> {

--- a/src/test/java/org/springframework/samples/petclinic/system/CrashControllerIntegrationTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/system/CrashControllerIntegrationTests.java
@@ -16,29 +16,22 @@
 
 package org.springframework.samples.petclinic.system;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 
-import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration;
 import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.context.annotation.Import;
 import org.springframework.core.ParameterizedTypeReference;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.http.RequestEntity;
-import org.springframework.http.ResponseEntity;
+import org.springframework.test.web.reactive.server.WebTestClient;
 import reactor.core.publisher.Flux;
 
 /**
@@ -47,48 +40,54 @@ import reactor.core.publisher.Flux;
  * @author Alex Lutz
  */
 // NOT Waiting https://github.com/spring-projects/spring-boot/issues/5574
-@SpringBootTest(webEnvironment = RANDOM_PORT,
-		properties = { "server.error.include-message=ALWAYS", "management.endpoints.enabled-by-default=false" })
+@Import(TestEnglishLocaleConfig.class)
+@SpringBootTest(webEnvironment = RANDOM_PORT, properties = { "server.error.include-message=ALWAYS" })
 class CrashControllerIntegrationTests {
 
-	@Value(value = "${local.server.port}")
-	private int port;
-
 	@Autowired
-	private TestRestTemplate rest;
+	private WebTestClient webTestClient;
 
 	@Test
 	void testTriggerExceptionJson() {
-		ResponseEntity<Map<String, Object>> resp = rest.exchange(
-				RequestEntity.get("http://localhost:" + port + "/oups").build(),
-				new ParameterizedTypeReference<Map<String, Object>>() {
-				});
-		assertThat(resp).isNotNull();
-		assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
-		assertThat(resp.getBody()).containsKey("timestamp");
-		assertThat(resp.getBody()).containsKey("status");
-		assertThat(resp.getBody()).containsKey("error");
-		assertThat(resp.getBody()).containsEntry("message",
-				"Expected: controller used to showcase what happens when an exception is thrown");
-		assertThat(resp.getBody()).containsEntry("path", "/oups");
+		webTestClient.get()
+			.uri("/oups")
+			.accept(MediaType.APPLICATION_JSON)
+			.exchange()
+			.expectStatus()
+			.isOk()
+			.expectBody()
+			// Since we're returning a view name, even with JSON accept header,
+			// we'll get HTML content due to the GlobalErrorHandler
+			.xpath("//html")
+			.exists()
+			.xpath("//body")
+			.exists()
+			.xpath("//p[contains(text(), 'Expected: controller used to showcase what happens when an exception is thrown')]")
+			.exists();
 	}
 
 	@Test
 	void testTriggerExceptionHtml() {
-		HttpHeaders headers = new HttpHeaders();
-		headers.setAccept(List.of(MediaType.TEXT_HTML));
-		ResponseEntity<String> resp = rest.exchange("http://localhost:" + port + "/oups", HttpMethod.GET,
-				new HttpEntity<>(headers), String.class);
-		assertThat(resp).isNotNull();
-		assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
-		assertThat(resp.getBody()).isNotNull();
-		// html:
-		assertThat(resp.getBody()).containsSubsequence("<body>", "<h2>", "Something happened...", "</h2>", "<p>",
-				"Expected:", "controller", "used", "to", "showcase", "what", "happens", "when", "an", "exception", "is",
-				"thrown", "</p>", "</body>");
-		// Not the whitelabel error page:
-		assertThat(resp.getBody()).doesNotContain("Whitelabel Error Page",
-				"This application has no explicit mapping for");
+		webTestClient.get()
+			.uri("/oups")
+			.accept(MediaType.TEXT_HTML)
+			.exchange()
+			.expectStatus()
+			.isOk()
+			.expectBody()
+			.xpath("//html")
+			.exists()
+			.xpath("//body")
+			.exists()
+			.xpath("//h2[contains(text(), 'Something happened')]")
+			.exists()
+			.xpath("//p[contains(text(), 'Expected: controller used to showcase what happens when an exception is thrown')]")
+			.exists()
+			// Not the whitelabel error page
+			.xpath("//h1[contains(text(), 'Whitelabel Error Page')]")
+			.doesNotExist()
+			.xpath("//*[contains(text(), 'This application has no explicit mapping for')]")
+			.doesNotExist();
 	}
 
 	@SpringBootApplication(exclude = { DataSourceAutoConfiguration.class,

--- a/src/test/java/org/springframework/samples/petclinic/system/CrashControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/system/CrashControllerTests.java
@@ -34,7 +34,7 @@ class CrashControllerTests {
 
 	@Test
 	void testTriggerException() {
-		assertThatExceptionOfType(RuntimeException.class).isThrownBy(() -> testee.triggerException())
+		assertThatExceptionOfType(RuntimeException.class).isThrownBy(() -> testee.triggerException().block())
 			.withMessageContaining("Expected: controller used to showcase what happens when an exception is thrown");
 	}
 


### PR DESCRIPTION
Make the crash controller reactive and handle exceptions globally using a custom reactive error handler.
Any exception raised by reactive controllers must render the error.html Thymeleaf view with the exception message available in the model, replacing the default whitelabel page.