### PR TITLE
Mock UUIDs for Deterministic and Repeatable Unit Testing

### DIFF
--- a/.ee-bench/codegen/metadata.json
+++ b/.ee-bench/codegen/metadata.json
@@ -5,7 +5,9 @@
   "jvm_version": "17",
   "expected": {
     "fail_to_pass": [],
-    "pass_to_pass": []
+    "pass_to_pass": [
+      "org.springframework.samples.petclinic.medication.MedicationRepositoryTest"
+    ]
   },
   "environment": {
     "project_root": "/repo",
@@ -13,7 +15,9 @@
       "run_params": {
         "privileged": true,
         "network": "host",
-        "volumes": ["/var/run/docker.sock:/var/run/docker.sock"],
+        "volumes": [
+          "/var/run/docker.sock:/var/run/docker.sock"
+        ],
         "environment": {
           "TESTCONTAINERS_RYUK_DISABLED": "true",
           "TESTCONTAINERS_CHECKS_DISABLE": "true",

--- a/src/test/java/org/springframework/samples/petclinic/medication/MedicationRepositoryTest.java
+++ b/src/test/java/org/springframework/samples/petclinic/medication/MedicationRepositoryTest.java
@@ -2,13 +2,17 @@ package org.springframework.samples.petclinic.medication;
 
 import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
 import java.util.Optional;
+import java.util.UUID;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 @DataJpaTest
 public class MedicationRepositoryTest {
@@ -25,6 +29,26 @@ public class MedicationRepositoryTest {
 
 		Optional<Medication> found = medicationRepository.findById(saved.getId());
 		assertTrue(found.isPresent());
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "b5f3db68-65b6-4dc6-bfd3-f5925f3f5eff", "427f69d5-7089-4cf0-b1f9-74d41811388a",
+			"40b9a15f-8e61-4d13-be1c-d06fa08ea8cb" })
+	@Transactional(Transactional.TxType.NEVER)
+	void testSeveralUuidsGenerated(String uuidString) {
+		UUID uuid = UUID.fromString(uuidString);
+		try (MockedStatic<UUID> uuidMockedStatic = Mockito.mockStatic(UUID.class)) {
+			uuidMockedStatic.when(UUID::randomUUID).thenReturn(uuid);
+			Medication medication = new Medication();
+			Medication saved = medicationRepository.save(medication);
+			assertEquals(uuid, saved.getId());
+
+			Optional<Medication> found = medicationRepository.findById(uuid);
+			assertTrue(found.isPresent());
+		}
+		finally {
+			Mockito.framework().clearInlineMocks();
+		}
 	}
 
 }


### PR DESCRIPTION
Enable deterministic UUID-based IDs for JPA entities during tests so repository calls can assert against known UUIDs without leaking side effects across tests.

The Medication entity must use a UUID as its ID, and tests should verify persistence and retrieval strictly through the JPA repository using that UUID. During tests, the UUID generation must be temporarily stubbed (e.g., static mocking of UUID.randomUUID) to emit known values so that the saved entity receives the expected UUID and can be fetched by it. Cover several UUID values in a parameterized way.