### PR TITLE
Add pagination to pets and visits REST controllers

### DIFF
--- a/.ee-bench/codegen/metadata.json
+++ b/.ee-bench/codegen/metadata.json
@@ -4,7 +4,10 @@
   "language": "java",
   "jvm_version": "17",
   "expected": {
-    "fail_to_pass": [],
+    "fail_to_pass": [
+      "org.springframework.samples.petclinic.owner.PetRestControllerTests",
+      "org.springframework.samples.petclinic.owner.VisitRestControllerTests"
+    ],
     "pass_to_pass": []
   },
   "environment": {
@@ -13,7 +16,9 @@
       "run_params": {
         "privileged": true,
         "network": "host",
-        "volumes": ["/var/run/docker.sock:/var/run/docker.sock"],
+        "volumes": [
+          "/var/run/docker.sock:/var/run/docker.sock"
+        ],
         "environment": {
           "TESTCONTAINERS_RYUK_DISABLED": "true",
           "TESTCONTAINERS_CHECKS_DISABLE": "true",

--- a/src/main/java/org/springframework/samples/petclinic/owner/PetRepository.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/PetRepository.java
@@ -17,6 +17,8 @@ package org.springframework.samples.petclinic.owner;
 
 import java.util.List;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -32,6 +34,15 @@ public interface PetRepository extends JpaRepository<Pet, Integer> {
 
 	/**
 	 * Find all pets for a given owner
+	 * @param ownerId the owner ID
+	 * @param pageable pagination information
+	 * @return a page of pets
+	 */
+	@Query("SELECT pet FROM Pet pet JOIN Owner owner ON pet.id IN (SELECT p.id FROM owner.pets p) WHERE owner.id = :ownerId")
+	Page<Pet> findByOwnerId(@Param("ownerId") Integer ownerId, Pageable pageable);
+
+	/**
+	 * Find all pets for a given owner (non-paginated)
 	 * @param ownerId the owner ID
 	 * @return a list of pets
 	 */

--- a/src/main/java/org/springframework/samples/petclinic/owner/PetRestController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/PetRestController.java
@@ -19,6 +19,9 @@ import java.net.URI;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -28,6 +31,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
@@ -57,11 +61,16 @@ public class PetRestController {
 
 	/**
 	 * Get all pets
-	 * @return a list of all pets
+	 * @param page the page number (1-based, defaults to 1)
+	 * @param size the page size (defaults to 10)
+	 * @return a page of pets
 	 */
 	@GetMapping("/pets")
-	public ResponseEntity<List<Pet>> getAllPets() {
-		List<Pet> pets = this.petRepository.findAll();
+	public ResponseEntity<Page<Pet>> getAllPets(@RequestParam(defaultValue = "1") int page,
+			@RequestParam(defaultValue = "10") int size) {
+
+		Pageable pageable = PageRequest.of(page - 1, size);
+		Page<Pet> pets = this.petRepository.findAll(pageable);
 		return ResponseEntity.ok(pets);
 	}
 
@@ -79,16 +88,21 @@ public class PetRestController {
 	/**
 	 * Get all pets for a specific owner
 	 * @param ownerId the owner ID
-	 * @return a list of pets for the given owner
+	 * @param page the page number (1-based, defaults to 1)
+	 * @param size the page size (defaults to 10)
+	 * @return a page of pets for the given owner
 	 */
 	@GetMapping("/owners/{ownerId}/pets")
-	public ResponseEntity<List<Pet>> getPetsByOwner(@PathVariable("ownerId") int ownerId) {
+	public ResponseEntity<Page<Pet>> getPetsByOwner(@PathVariable("ownerId") int ownerId,
+			@RequestParam(defaultValue = "1") int page, @RequestParam(defaultValue = "10") int size) {
+
 		// Check if owner exists
 		if (!this.ownerRepository.existsById(ownerId)) {
 			return ResponseEntity.notFound().build();
 		}
 
-		List<Pet> pets = this.petRepository.findByOwnerId(ownerId);
+		Pageable pageable = PageRequest.of(page - 1, size);
+		Page<Pet> pets = this.petRepository.findByOwnerId(ownerId, pageable);
 		return ResponseEntity.ok(pets);
 	}
 

--- a/src/main/java/org/springframework/samples/petclinic/owner/VisitRepository.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/VisitRepository.java
@@ -17,6 +17,8 @@ package org.springframework.samples.petclinic.owner;
 
 import java.util.List;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -32,6 +34,15 @@ public interface VisitRepository extends JpaRepository<Visit, Integer> {
 
 	/**
 	 * Find all visits for a given pet
+	 * @param petId the pet ID
+	 * @param pageable pagination information
+	 * @return a page of visits
+	 */
+	@Query("SELECT visit FROM Visit visit WHERE visit.id IN (SELECT v.id FROM Pet pet JOIN pet.visits v WHERE pet.id = :petId)")
+	Page<Visit> findByPetId(@Param("petId") Integer petId, Pageable pageable);
+
+	/**
+	 * Find all visits for a given pet (non-paginated)
 	 * @param petId the pet ID
 	 * @return a list of visits
 	 */

--- a/src/main/java/org/springframework/samples/petclinic/owner/VisitRestController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/VisitRestController.java
@@ -19,6 +19,9 @@ import java.net.URI;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -27,6 +30,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
@@ -52,11 +56,16 @@ public class VisitRestController {
 
 	/**
 	 * Get all visits
-	 * @return a list of all visits
+	 * @param page the page number (1-based, defaults to 1)
+	 * @param size the page size (defaults to 10)
+	 * @return a page of visits
 	 */
 	@GetMapping("/visits")
-	public ResponseEntity<List<Visit>> getAllVisits() {
-		List<Visit> visits = this.visitRepository.findAll();
+	public ResponseEntity<Page<Visit>> getAllVisits(@RequestParam(defaultValue = "1") int page,
+			@RequestParam(defaultValue = "10") int size) {
+
+		Pageable pageable = PageRequest.of(page - 1, size);
+		Page<Visit> visits = this.visitRepository.findAll(pageable);
 		return ResponseEntity.ok(visits);
 	}
 
@@ -74,16 +83,21 @@ public class VisitRestController {
 	/**
 	 * Get all visits for a specific pet
 	 * @param petId the pet ID
-	 * @return a list of visits for the given pet
+	 * @param page the page number (1-based, defaults to 1)
+	 * @param size the page size (defaults to 10)
+	 * @return a page of visits for the given pet
 	 */
 	@GetMapping("/pets/{petId}/visits")
-	public ResponseEntity<List<Visit>> getVisitsByPet(@PathVariable("petId") int petId) {
+	public ResponseEntity<Page<Visit>> getVisitsByPet(@PathVariable("petId") int petId,
+			@RequestParam(defaultValue = "1") int page, @RequestParam(defaultValue = "10") int size) {
+
 		// Check if pet exists
 		if (!this.petRepository.existsById(petId)) {
 			return ResponseEntity.notFound().build();
 		}
 
-		List<Visit> visits = this.visitRepository.findByPetId(petId);
+		Pageable pageable = PageRequest.of(page - 1, size);
+		Page<Visit> visits = this.visitRepository.findByPetId(petId, pageable);
 		return ResponseEntity.ok(visits);
 	}
 


### PR DESCRIPTION
Implement pagination for the endpoints that return lists of pets and visits in the PetRestController and VisitRestController. Modify the corresponding repository methods to support pagination and adjust the response types in the controllers accordingly. Add necessary parameters for page number and page size to the appropriate methods, ensuring default values are provided. Update the documentation for the methods to reflect these changes.