### PR TITLE
#73 Add transactional boundaries to the reactive service layer to ensure that database operations...

### DIFF
--- a/.ee-bench/codegen/metadata.json
+++ b/.ee-bench/codegen/metadata.json
@@ -1,0 +1,17 @@
+{
+  "instance_id": "dpaia__spring__petclinic-73",
+  "base_commit": "399850b79e354992140d519e3a5107ce0cdbf851",
+  "expected": {
+    "fail_to_pass": [
+      "org.springframework.samples.petclinic.owner.OwnerServiceTransactionTest"
+    ],
+    "pass_to_pass": []
+  },
+  "issue_numbers": [
+    "73"
+  ],
+  "tags": [
+    "Transaction",
+    "Reactive"
+  ]
+}

--- a/src/main/java/org/springframework/samples/petclinic/owner/OwnerServiceImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/OwnerServiceImpl.java
@@ -18,10 +18,12 @@ package org.springframework.samples.petclinic.owner;
 import jakarta.annotation.Nullable;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 @Service
+@Transactional(readOnly = true)
 public class OwnerServiceImpl implements OwnerService {
 
 	private final OwnerRepository ownerRepository;
@@ -40,6 +42,7 @@ public class OwnerServiceImpl implements OwnerService {
 	}
 
 	@Override
+	@Transactional
 	public Mono<Owner> save(Owner owner) {
 		return ownerRepository.save(owner);
 	}

--- a/src/main/java/org/springframework/samples/petclinic/owner/PetServiceImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/PetServiceImpl.java
@@ -16,10 +16,12 @@
 package org.springframework.samples.petclinic.owner;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 @Service
+@Transactional(readOnly = true)
 public class PetServiceImpl implements PetService {
 
 	private final PetRepository petRepository;
@@ -67,6 +69,7 @@ public class PetServiceImpl implements PetService {
 	}
 
 	@Override
+	@Transactional
 	public Mono<Pet> save(Owner owner, Pet pet) {
 		pet.setOwnerId(owner.getId());
 		return petRepository.save(pet);

--- a/src/main/java/org/springframework/samples/petclinic/owner/VisitServiceImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/VisitServiceImpl.java
@@ -16,9 +16,11 @@
 package org.springframework.samples.petclinic.owner;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import reactor.core.publisher.Mono;
 
 @Service
+@Transactional(readOnly = true)
 public class VisitServiceImpl implements VisitService {
 
 	private final VisitRepository visitRepository;
@@ -28,6 +30,7 @@ public class VisitServiceImpl implements VisitService {
 	}
 
 	@Override
+	@Transactional
 	public Mono<Visit> save(Visit visit) {
 		return visitRepository.save(visit);
 	}

--- a/src/main/java/org/springframework/samples/petclinic/vet/VetServiceImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/vet/VetServiceImpl.java
@@ -17,6 +17,7 @@ package org.springframework.samples.petclinic.vet;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -24,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 
 @Service
+@Transactional(readOnly = true)
 public class VetServiceImpl implements VetService {
 
 	private final VetRepository vetRepository;

--- a/src/test/java/org/springframework/samples/petclinic/owner/OwnerServiceTransactionTest.java
+++ b/src/test/java/org/springframework/samples/petclinic/owner/OwnerServiceTransactionTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2012-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.samples.petclinic.owner;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.samples.petclinic.system.TestTransactionConfig;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Import(TestTransactionConfig.class)
+@SpringBootTest
+public class OwnerServiceTransactionTest {
+
+	@Autowired
+	OwnerService ownerService;
+
+	@Autowired
+	TestTransactionConfig transactionConfig;
+
+	@Test
+	public void shouldStartTransaction() {
+		var owner = ownerService.findByIdReactive(1).block();
+		ownerService.save(owner).block();
+
+		assertEquals(3, transactionConfig.getCount());
+	}
+
+}

--- a/src/test/java/org/springframework/samples/petclinic/system/TestTransactionConfig.java
+++ b/src/test/java/org/springframework/samples/petclinic/system/TestTransactionConfig.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2012-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.samples.petclinic.system;
+
+import org.jetbrains.annotations.NotNull;
+import org.springframework.context.annotation.Bean;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.transaction.ReactiveTransaction;
+import org.springframework.transaction.ReactiveTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import reactor.core.publisher.Mono;
+
+@TestConfiguration
+public class TestTransactionConfig {
+
+	public Integer getCount() {
+		return count;
+	}
+
+	private Integer count = 0;
+
+	@Bean
+	public ReactiveTransactionManager reactiveTransactionManager() {
+		return new TestTransactionManager();
+	}
+
+	public class TestTransactionManager implements ReactiveTransactionManager {
+
+		@Override
+		public @NotNull Mono<ReactiveTransaction> getReactiveTransaction(TransactionDefinition definition) {
+			count++;
+			return Mono.just(new TestTransactionManager.DummyReactiveTransaction());
+		}
+
+		@Override
+		public @NotNull Mono<Void> commit(@NotNull ReactiveTransaction transaction) {
+			return Mono.empty();
+		}
+
+		@Override
+		public @NotNull Mono<Void> rollback(@NotNull ReactiveTransaction transaction) {
+			return Mono.empty();
+		}
+
+		private static class DummyReactiveTransaction implements ReactiveTransaction {
+
+			@Override
+			public void setRollbackOnly() {
+			}
+
+		}
+
+	}
+
+}


### PR DESCRIPTION
Add transactional boundaries to the reactive service layer to ensure that database operations executed within reactive flows are properly wrapped in Spring-managed transactions.
Annotate service classes and their mutating methods with @​Transactional to enable transaction start and commit behavior.
