### PR TITLE
#76 Spring WebFlux does not provide native pagination support. Implement manual pagination for the...

### DIFF
--- a/.ee-bench/codegen/metadata.json
+++ b/.ee-bench/codegen/metadata.json
@@ -1,0 +1,21 @@
+{
+  "instance_id": "dpaia__spring__petclinic-76",
+  "base_commit": "6f3dc469014774648f39b7304c11d5db85c22dd8",
+  "expected": {
+    "fail_to_pass": [
+      "org.springframework.samples.petclinic.owner.OwnerControllerTests#testPageWithPaginationWithNumberNotMultipleOf5",
+      "org.springframework.samples.petclinic.owner.OwnerControllerTests#testPageWithoutPagination",
+      "org.springframework.samples.petclinic.vet.VetControllerTests#testPageWithPagination"
+    ],
+    "pass_to_pass": [
+      "org.springframework.samples.petclinic.service.ClinicServiceTests"
+    ]
+  },
+  "issue_numbers": [
+    "76"
+  ],
+  "tags": [
+    "Controller",
+    "Reactive"
+  ]
+}

--- a/src/main/java/org/springframework/samples/petclinic/owner/OwnerService.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/OwnerService.java
@@ -17,15 +17,17 @@ package org.springframework.samples.petclinic.owner;
 
 import jakarta.annotation.Nullable;
 import org.springframework.data.domain.Pageable;
-import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.util.function.Tuple2;
+
+import java.util.List;
 
 /**
  * Service for {@link Owner} domain objects.
  */
 public interface OwnerService {
 
-	Flux<Owner> findByLastNameStartingWithReactive(@Nullable String lastName, Pageable pageable);
+	Mono<Tuple2<List<Owner>, Long>> findByLastNameStartingWithReactive(@Nullable String lastName, Pageable pageable);
 
 	Mono<Owner> save(Owner owner);
 

--- a/src/main/java/org/springframework/samples/petclinic/owner/OwnerServiceImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/OwnerServiceImpl.java
@@ -21,6 +21,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.util.function.Tuple2;
+
+import java.util.List;
 
 @Service
 @Transactional(readOnly = true)
@@ -36,9 +39,11 @@ public class OwnerServiceImpl implements OwnerService {
 	}
 
 	@Override
-	public Flux<Owner> findByLastNameStartingWithReactive(@Nullable String lastName, Pageable pageable) {
-		return ownerRepository.findByLastNameStartingWith(lastName == null ? "" : lastName, pageable)
+	public Mono<Tuple2<List<Owner>, Long>> findByLastNameStartingWithReactive(@Nullable String lastName,
+			Pageable pageable) {
+		Flux<Owner> owners = ownerRepository.findByLastNameStartingWith(lastName == null ? "" : lastName, pageable)
 			.flatMap(this::load);
+		return owners.collectList().zipWith(ownerRepository.count());
 	}
 
 	@Override

--- a/src/main/java/org/springframework/samples/petclinic/vet/VetService.java
+++ b/src/main/java/org/springframework/samples/petclinic/vet/VetService.java
@@ -16,8 +16,10 @@
 package org.springframework.samples.petclinic.vet;
 
 import org.springframework.data.domain.Pageable;
-import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.util.function.Tuple2;
+
+import java.util.List;
 
 /**
  * Service for {@link Vet} domain objects.
@@ -26,6 +28,6 @@ public interface VetService {
 
 	Mono<Vets> getVetsAsListReactive();
 
-	Flux<Vet> findAllPaginatedReactive(Pageable pageable);
+	Mono<Tuple2<List<Vet>, Long>> findAllPaginatedReactive(Pageable pageable);
 
 }

--- a/src/main/java/org/springframework/samples/petclinic/vet/VetServiceImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/vet/VetServiceImpl.java
@@ -20,6 +20,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.util.function.Tuple2;
 
 import java.util.List;
 import java.util.Map;
@@ -51,8 +52,9 @@ public class VetServiceImpl implements VetService {
 	}
 
 	@Override
-	public Flux<Vet> findAllPaginatedReactive(Pageable pageable) {
-		return vetRepository.findAllBy(pageable).flatMap(this::load);
+	public Mono<Tuple2<List<Vet>, Long>> findAllPaginatedReactive(Pageable pageable) {
+		Flux<Vet> vets = vetRepository.findAllBy(pageable).flatMap(this::load);
+		return vets.collectList().zipWith(vetRepository.count());
 	}
 
 	private Mono<Vet> load(Vet vet) {

--- a/src/test/java/org/springframework/samples/petclinic/owner/OwnerControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/owner/OwnerControllerTests.java
@@ -24,6 +24,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.samples.petclinic.system.TestEnglishLocaleConfig;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.aot.DisabledInAotMode;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import org.springframework.web.reactive.function.BodyInserters;
@@ -58,6 +59,7 @@ class OwnerControllerTests {
 	}
 
 	@Test
+	@DirtiesContext
 	void testProcessCreationFormSuccess() {
 		webTestClient.post()
 			.uri("/owners/new")
@@ -152,6 +154,7 @@ class OwnerControllerTests {
 	}
 
 	@Test
+	@DirtiesContext
 	void testProcessUpdateOwnerFormSuccess() {
 		webTestClient.post()
 			.uri("/owners/{ownerId}/edit", 2)
@@ -227,6 +230,39 @@ class OwnerControllerTests {
 			.xpath("//th[normalize-space(text())='Telephone']/following-sibling::td[normalize-space(text())='6085551023']")
 			.exists()
 			.xpath("//dt[normalize-space(text())='Name']/following-sibling::dd[1][normalize-space(text())='Leo']")
+			.exists();
+	}
+
+	@Test
+	void testPageWithoutPagination() {
+		webTestClient.get()
+			.uri("/owners?page=1&lastName=Davis")
+			.exchange()
+			.expectStatus()
+			.isOk()
+			.expectBody()
+			.xpath("//a[@href='/owners?page=1' and text()='1']")
+			.doesNotExist();
+	}
+
+	@Test
+	@DirtiesContext
+	void testPageWithPaginationWithNumberNotMultipleOf5() {
+		webTestClient.post()
+			.uri("/owners/new")
+			.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+			.bodyValue("firstName=Joe&lastName=Bloggs&address=123 Caramel Street&city=London&telephone=1316761638")
+			.exchange()
+			.expectStatus()
+			.is3xxRedirection();
+
+		webTestClient.get()
+			.uri("/owners")
+			.exchange()
+			.expectStatus()
+			.isOk()
+			.expectBody()
+			.xpath("//a[@href='/owners?page=3' and text()='3']")
 			.exists();
 	}
 

--- a/src/test/java/org/springframework/samples/petclinic/service/ClinicServiceTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/service/ClinicServiceTests.java
@@ -34,6 +34,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.samples.petclinic.vet.Vet;
 import org.springframework.samples.petclinic.vet.VetService;
+import reactor.util.function.Tuple2;
 
 /**
  * Integration test of the Service and the Repository layer.
@@ -89,13 +90,13 @@ class ClinicServiceTests {
 	@Test
 	void shouldFindOwnersByLastName() {
 		this.ownerService.findByLastNameStartingWithReactive("Davis", pageable)
-			.collectList()
+			.map(Tuple2::getT1)
 			.as(StepVerifier::create)
 			.expectNextMatches(owners -> owners.size() == 2)
 			.verifyComplete();
 
 		this.ownerService.findByLastNameStartingWithReactive("Daviss", pageable)
-			.collectList()
+			.map(Tuple2::getT1)
 			.as(StepVerifier::create)
 			.expectNextMatches(List::isEmpty)
 			.verifyComplete();
@@ -116,7 +117,7 @@ class ClinicServiceTests {
 	void shouldInsertOwner() {
 		// First, find existing owners with last name "Schultz"
 		this.ownerService.findByLastNameStartingWithReactive("Schultz", pageable)
-			.collectList()
+			.map(Tuple2::getT1)
 			.flatMap(existingOwners -> {
 				int found = existingOwners.size();
 
@@ -136,7 +137,7 @@ class ClinicServiceTests {
 
 					// Find owners again and verify count increased
 					return this.ownerService.findByLastNameStartingWithReactive("Schultz", pageable)
-						.collectList()
+						.map(Tuple2::getT1)
 						.flatMap(updatedOwners -> {
 							if (updatedOwners.size() != found + 1) {
 								return Mono.just(new AssertionError(
@@ -229,7 +230,7 @@ class ClinicServiceTests {
 	@Test
 	void shouldFindVets() {
 		this.vetService.findAllPaginatedReactive(pageable)
-			.collectList()
+			.map(Tuple2::getT1)
 			.as(StepVerifier::create)
 			.expectNextMatches(vets -> {
 				Vet vet = EntityUtils.getById(vets, Vet.class, 3);

--- a/src/test/java/org/springframework/samples/petclinic/vet/VetControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/vet/VetControllerTests.java
@@ -68,4 +68,16 @@ class VetControllerTests {
 			.isEqualTo(1);
 	}
 
+	@Test
+	void testPageWithPagination() {
+		webTestClient.get()
+			.uri("/vets.html")
+			.exchange()
+			.expectStatus()
+			.isOk()
+			.expectBody()
+			.xpath("//a[@href='/vets.html?page=2' and text()='2']")
+			.exists();
+	}
+
 }


### PR DESCRIPTION
Spring WebFlux does not provide native pagination support. Implement manual pagination for the /owners and /vets endpoints. Ensure that the response includes the current page and total number of pages.
