### PR TITLE
#71 Start the migration to a reactive stack by transitioning the persistence layer from JPA to R2DBC.

### DIFF
--- a/.ee-bench/codegen/metadata.json
+++ b/.ee-bench/codegen/metadata.json
@@ -1,0 +1,20 @@
+{
+  "instance_id": "dpaia__spring__petclinic-71",
+  "base_commit": "30aab0ae764ad845b5eedd76028756835fec771f",
+  "expected": {
+    "fail_to_pass": [
+      "org.springframework.samples.petclinic.vet.R2dbcVetRepositoryTests",
+      "org.springframework.samples.petclinic.owner.R2dbcVisitRepositoryTests",
+      "org.springframework.samples.petclinic.owner.R2dbcPetRepositoryTests",
+      "org.springframework.samples.petclinic.owner.R2dbcOwnerRepositoryTests"
+    ],
+    "pass_to_pass": []
+  },
+  "issue_numbers": [
+    "71"
+  ],
+  "tags": [
+    "Data",
+    "Reactive"
+  ]
+}

--- a/build.gradle
+++ b/build.gradle
@@ -32,18 +32,22 @@ ext.webjarsBootstrapVersion = "5.3.6"
 
 dependencies {
   implementation 'org.springframework.boot:spring-boot-starter-cache'
-  implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+  implementation 'org.springframework.boot:spring-boot-starter-data-r2dbc'
   implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
   implementation 'org.springframework.boot:spring-boot-starter-web'
   implementation 'org.springframework.boot:spring-boot-starter-validation'
   implementation 'javax.cache:cache-api'
   implementation 'jakarta.xml.bind:jakarta.xml.bind-api'
+  implementation 'io.projectreactor:reactor-core'
+  runtimeOnly 'io.r2dbc:r2dbc-pool'
+  testImplementation 'io.projectreactor:reactor-test'
+  testImplementation 'org.testcontainers:db2'
+  runtimeOnly 'io.r2dbc:r2dbc-h2'
   runtimeOnly 'org.springframework.boot:spring-boot-starter-actuator'
   runtimeOnly "org.webjars:webjars-locator-lite:${webjarsLocatorLiteVersion}"
   runtimeOnly "org.webjars.npm:bootstrap:${webjarsBootstrapVersion}"
   runtimeOnly "org.webjars.npm:font-awesome:${webjarsFontawesomeVersion}"
   runtimeOnly 'com.github.ben-manes.caffeine:caffeine'
-  runtimeOnly 'com.h2database:h2'
   runtimeOnly 'com.mysql:mysql-connector-j'
   runtimeOnly 'org.postgresql:postgresql'
   developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-data-jpa</artifactId>
+      <artifactId>spring-boot-starter-data-r2dbc</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -72,9 +72,10 @@
     </dependency>
 
     <!-- Databases - Uses H2 by default -->
+    <!-- R2DBC H2 runtime instead of JDBC H2 -->
     <dependency>
-      <groupId>com.h2database</groupId>
-      <artifactId>h2</artifactId>
+      <groupId>io.r2dbc</groupId>
+      <artifactId>r2dbc-h2</artifactId>
       <scope>runtime</scope>
     </dependency>
     <dependency>
@@ -85,6 +86,13 @@
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+
+    <!-- R2DBC Connection Pool -->
+    <dependency>
+      <groupId>io.r2dbc</groupId>
+      <artifactId>r2dbc-pool</artifactId>
       <scope>runtime</scope>
     </dependency>
 
@@ -115,6 +123,12 @@
       <version>${webjars-font-awesome.version}</version>
     </dependency>
 
+    <!-- Reactor Core -->
+    <dependency>
+      <groupId>io.projectreactor</groupId>
+      <artifactId>reactor-core</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-devtools</artifactId>
@@ -138,6 +152,17 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>mysql</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>db2</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <!-- Reactor Test -->
+    <dependency>
+      <groupId>io.projectreactor</groupId>
+      <artifactId>reactor-test</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/src/main/java/org/springframework/samples/petclinic/model/BaseEntity.java
+++ b/src/main/java/org/springframework/samples/petclinic/model/BaseEntity.java
@@ -17,10 +17,8 @@ package org.springframework.samples.petclinic.model;
 
 import java.io.Serializable;
 
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.MappedSuperclass;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Column;
 
 /**
  * Simple JavaBean domain object with an id property. Used as a base class for objects
@@ -29,11 +27,10 @@ import jakarta.persistence.MappedSuperclass;
  * @author Ken Krebs
  * @author Juergen Hoeller
  */
-@MappedSuperclass
 public class BaseEntity implements Serializable {
 
 	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column("id")
 	private Integer id;
 
 	public Integer getId() {

--- a/src/main/java/org/springframework/samples/petclinic/model/NamedEntity.java
+++ b/src/main/java/org/springframework/samples/petclinic/model/NamedEntity.java
@@ -15,8 +15,7 @@
  */
 package org.springframework.samples.petclinic.model;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.MappedSuperclass;
+import org.springframework.data.relational.core.mapping.Column;
 import jakarta.validation.constraints.NotBlank;
 
 /**
@@ -27,10 +26,9 @@ import jakarta.validation.constraints.NotBlank;
  * @author Juergen Hoeller
  * @author Wick Dynex
  */
-@MappedSuperclass
 public class NamedEntity extends BaseEntity {
 
-	@Column(name = "name")
+	@Column("name")
 	@NotBlank
 	private String name;
 

--- a/src/main/java/org/springframework/samples/petclinic/model/Person.java
+++ b/src/main/java/org/springframework/samples/petclinic/model/Person.java
@@ -15,8 +15,7 @@
  */
 package org.springframework.samples.petclinic.model;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.MappedSuperclass;
+import org.springframework.data.relational.core.mapping.Column;
 import jakarta.validation.constraints.NotBlank;
 
 /**
@@ -24,14 +23,13 @@ import jakarta.validation.constraints.NotBlank;
  *
  * @author Ken Krebs
  */
-@MappedSuperclass
 public class Person extends BaseEntity {
 
-	@Column(name = "first_name")
+	@Column("first_name")
 	@NotBlank
 	private String firstName;
 
-	@Column(name = "last_name")
+	@Column("last_name")
 	@NotBlank
 	private String lastName;
 

--- a/src/main/java/org/springframework/samples/petclinic/owner/Owner.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/Owner.java
@@ -19,17 +19,12 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.core.style.ToStringCreator;
+import org.springframework.data.annotation.Transient;
+import org.springframework.data.relational.core.mapping.Column;
+import org.springframework.data.relational.core.mapping.Table;
 import org.springframework.samples.petclinic.model.Person;
 import org.springframework.util.Assert;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.OrderBy;
-import jakarta.persistence.Table;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.NotBlank;
 
@@ -43,26 +38,23 @@ import jakarta.validation.constraints.NotBlank;
  * @author Oliver Drotbohm
  * @author Wick Dynex
  */
-@Entity
-@Table(name = "owners")
+@Table("owners")
 public class Owner extends Person {
 
-	@Column(name = "address")
+	@Column("address")
 	@NotBlank
 	private String address;
 
-	@Column(name = "city")
+	@Column("city")
 	@NotBlank
 	private String city;
 
-	@Column(name = "telephone")
+	@Column("telephone")
 	@NotBlank
 	@Pattern(regexp = "\\d{10}", message = "{telephone.invalid}")
 	private String telephone;
 
-	@OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER)
-	@JoinColumn(name = "owner_id")
-	@OrderBy("name")
+	@Transient
 	private final List<Pet> pets = new ArrayList<>();
 
 	public String getAddress() {
@@ -94,9 +86,7 @@ public class Owner extends Person {
 	}
 
 	public void addPet(Pet pet) {
-		if (pet.isNew()) {
-			getPets().add(pet);
-		}
+		getPets().add(pet);
 	}
 
 	/**
@@ -156,20 +146,20 @@ public class Owner extends Person {
 	}
 
 	/**
-	 * Adds the given {@link Visit} to the {@link Pet} with the given identifier.
+	 * Sets the petId on the given {@link Visit}.
 	 * @param petId the identifier of the {@link Pet}, must not be {@literal null}.
 	 * @param visit the visit to add, must not be {@literal null}.
 	 */
 	public void addVisit(Integer petId, Visit visit) {
-
-		Assert.notNull(petId, "Pet identifier must not be null!");
-		Assert.notNull(visit, "Visit must not be null!");
-
+		// Validate that the pet exists
 		Pet pet = getPet(petId);
-
 		Assert.notNull(pet, "Invalid Pet identifier!");
 
-		pet.addVisit(visit);
+		// Set the petId on the visit directly
+		visit.setPetId(petId);
+
+		// For backward compatibility, still add to the pet's visits collection
+		pet.getVisits().add(visit);
 	}
 
 }

--- a/src/main/java/org/springframework/samples/petclinic/owner/OwnerRepository.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/OwnerRepository.java
@@ -15,20 +15,15 @@
  */
 package org.springframework.samples.petclinic.owner;
 
-import java.util.List;
-import java.util.Optional;
-
-import jakarta.annotation.Nonnull;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.r2dbc.repository.R2dbcRepository;
+import reactor.core.publisher.Flux;
 
 /**
  * Repository class for <code>Owner</code> domain objects. All method names are compliant
  * with Spring Data naming conventions so this interface can easily be extended for Spring
  * Data. See:
- * https://docs.spring.io/spring-data/jpa/docs/current/reference/html/#repositories.query-methods.query-creation
+ * https://docs.spring.io/spring-data/r2dbc/docs/current/reference/html/#repositories
  *
  * @author Ken Krebs
  * @author Juergen Hoeller
@@ -36,30 +31,15 @@ import org.springframework.data.jpa.repository.Query;
  * @author Michael Isvy
  * @author Wick Dynex
  */
-public interface OwnerRepository extends JpaRepository<Owner, Integer> {
+public interface OwnerRepository extends R2dbcRepository<Owner, Integer> {
 
 	/**
 	 * Retrieve {@link Owner}s from the data store by last name, returning all owners
 	 * whose last name <i>starts</i> with the given name.
 	 * @param lastName Value to search for
-	 * @return a Collection of matching {@link Owner}s (or an empty Collection if none
-	 * found)
+	 * @param pageable Pagination information
+	 * @return a Flux of matching {@link Owner}s (or an empty Flux if none found)
 	 */
-	Page<Owner> findByLastNameStartingWith(String lastName, Pageable pageable);
-
-	/**
-	 * Retrieve an {@link Owner} from the data store by id.
-	 * <p>
-	 * This method returns an {@link Optional} containing the {@link Owner} if found. If
-	 * no {@link Owner} is found with the provided id, it will return an empty
-	 * {@link Optional}.
-	 * </p>
-	 * @param id the id to search for
-	 * @return an {@link Optional} containing the {@link Owner} if found, or an empty
-	 * {@link Optional} if not found.
-	 * @throws IllegalArgumentException if the id is null (assuming null is not a valid
-	 * input for id)
-	 */
-	Optional<Owner> findById(@Nonnull Integer id);
+	Flux<Owner> findByLastNameStartingWith(String lastName, Pageable pageable);
 
 }

--- a/src/main/java/org/springframework/samples/petclinic/owner/Pet.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/Pet.java
@@ -20,18 +20,11 @@ import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
+import org.springframework.data.annotation.Transient;
+import org.springframework.data.relational.core.mapping.Column;
+import org.springframework.data.relational.core.mapping.Table;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.samples.petclinic.model.NamedEntity;
-
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.OrderBy;
-import jakarta.persistence.Table;
 
 /**
  * Simple business object representing a pet.
@@ -41,21 +34,23 @@ import jakarta.persistence.Table;
  * @author Sam Brannen
  * @author Wick Dynex
  */
-@Entity
-@Table(name = "pets")
+@Table("pets")
 public class Pet extends NamedEntity {
 
-	@Column(name = "birth_date")
+	@Column("birth_date")
 	@DateTimeFormat(pattern = "yyyy-MM-dd")
 	private LocalDate birthDate;
 
-	@ManyToOne
-	@JoinColumn(name = "type_id")
+	@Column("type_id")
+	private Integer typeId;
+
+	@Column("owner_id")
+	private Integer ownerId;
+
+	@Transient
 	private PetType type;
 
-	@OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER)
-	@JoinColumn(name = "pet_id")
-	@OrderBy("date ASC")
+	@Transient
 	private final Set<Visit> visits = new LinkedHashSet<>();
 
 	public void setBirthDate(LocalDate birthDate) {
@@ -72,6 +67,25 @@ public class Pet extends NamedEntity {
 
 	public void setType(PetType type) {
 		this.type = type;
+		if (type != null) {
+			this.typeId = type.getId();
+		}
+	}
+
+	public Integer getTypeId() {
+		return this.typeId;
+	}
+
+	public void setTypeId(Integer typeId) {
+		this.typeId = typeId;
+	}
+
+	public Integer getOwnerId() {
+		return this.ownerId;
+	}
+
+	public void setOwnerId(Integer ownerId) {
+		this.ownerId = ownerId;
 	}
 
 	public Collection<Visit> getVisits() {
@@ -79,6 +93,9 @@ public class Pet extends NamedEntity {
 	}
 
 	public void addVisit(Visit visit) {
+		// Set the petId on the visit
+		visit.setPetId(this.getId());
+		// Still add to transient collection for backward compatibility
 		getVisits().add(visit);
 	}
 

--- a/src/main/java/org/springframework/samples/petclinic/owner/PetController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/PetController.java
@@ -57,12 +57,12 @@ class PetController {
 
 	@ModelAttribute("types")
 	public Collection<PetType> populatePetTypes() {
-		return this.types.findPetTypes();
+		return this.types.findPetTypes().collectList().block();
 	}
 
 	@ModelAttribute("owner")
 	public Owner findOwner(@PathVariable("ownerId") int ownerId) {
-		Optional<Owner> optionalOwner = this.owners.findById(ownerId);
+		Optional<Owner> optionalOwner = this.owners.findById(ownerId).blockOptional();
 		Owner owner = optionalOwner.orElseThrow(() -> new IllegalArgumentException(
 				"Owner not found with id: " + ownerId + ". Please ensure the ID is correct "));
 		return owner;
@@ -76,7 +76,7 @@ class PetController {
 			return new Pet();
 		}
 
-		Optional<Owner> optionalOwner = this.owners.findById(ownerId);
+		Optional<Owner> optionalOwner = this.owners.findById(ownerId).blockOptional();
 		Owner owner = optionalOwner.orElseThrow(() -> new IllegalArgumentException(
 				"Owner not found with id: " + ownerId + ". Please ensure the ID is correct "));
 		return owner.getPet(petId);
@@ -116,7 +116,7 @@ class PetController {
 		}
 
 		owner.addPet(pet);
-		this.owners.save(owner);
+		this.owners.save(owner).block();
 		redirectAttributes.addFlashAttribute("message", "New Pet has been Added");
 		return "redirect:/owners/{ownerId}";
 	}
@@ -170,7 +170,7 @@ class PetController {
 		else {
 			owner.addPet(pet);
 		}
-		this.owners.save(owner);
+		this.owners.save(owner).block();
 	}
 
 }

--- a/src/main/java/org/springframework/samples/petclinic/owner/PetRepository.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/PetRepository.java
@@ -13,26 +13,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.springframework.samples.petclinic.owner;
 
-import org.springframework.data.r2dbc.repository.Query;
 import org.springframework.data.r2dbc.repository.R2dbcRepository;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 /**
- * Repository class for <code>PetType</code> domain objects.
- *
- * @author Patrick Baumgartner
+ * Repository class for <code>Pet</code> domain objects. All method names are compliant
+ * with Spring Data naming conventions so this interface can easily be extended for Spring
+ * Data. See:
+ * https://docs.spring.io/spring-data/r2dbc/docs/current/reference/html/#repositories
  */
-
-public interface PetTypeRepository extends R2dbcRepository<PetType, Integer> {
+public interface PetRepository extends R2dbcRepository<Pet, Integer> {
 
 	/**
-	 * Retrieve all {@link PetType}s from the data store ordered by name.
-	 * @return a Flux of {@link PetType}s.
+	 * Find all pets for an owner.
+	 * @param ownerId the owner id
+	 * @return a Flux of Pet objects
 	 */
-	@Query("SELECT ptype FROM PetType ptype ORDER BY ptype.name")
-	Flux<PetType> findPetTypes();
+	Flux<Pet> findByOwnerId(Integer ownerId);
+
+	Mono<Pet> findByIdAndOwnerId(Integer id, Integer ownerId);
 
 }

--- a/src/main/java/org/springframework/samples/petclinic/owner/PetType.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/PetType.java
@@ -15,16 +15,13 @@
  */
 package org.springframework.samples.petclinic.owner;
 
+import org.springframework.data.relational.core.mapping.Table;
 import org.springframework.samples.petclinic.model.NamedEntity;
-
-import jakarta.persistence.Entity;
-import jakarta.persistence.Table;
 
 /**
  * @author Juergen Hoeller Can be Cat, Dog, Hamster...
  */
-@Entity
-@Table(name = "types")
+@Table("types")
 public class PetType extends NamedEntity {
 
 }

--- a/src/main/java/org/springframework/samples/petclinic/owner/PetTypeFormatter.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/PetTypeFormatter.java
@@ -48,7 +48,7 @@ public class PetTypeFormatter implements Formatter<PetType> {
 
 	@Override
 	public PetType parse(String text, Locale locale) throws ParseException {
-		Collection<PetType> findPetTypes = this.types.findPetTypes();
+		Collection<PetType> findPetTypes = this.types.findPetTypes().collectList().block();
 		for (PetType type : findPetTypes) {
 			if (type.getName().equals(text)) {
 				return type;

--- a/src/main/java/org/springframework/samples/petclinic/owner/Visit.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/Visit.java
@@ -17,12 +17,11 @@ package org.springframework.samples.petclinic.owner;
 
 import java.time.LocalDate;
 
+import org.springframework.data.relational.core.mapping.Column;
+import org.springframework.data.relational.core.mapping.Table;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.samples.petclinic.model.BaseEntity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotBlank;
 
 /**
@@ -31,16 +30,19 @@ import jakarta.validation.constraints.NotBlank;
  * @author Ken Krebs
  * @author Dave Syer
  */
-@Entity
-@Table(name = "visits")
+@Table("visits")
 public class Visit extends BaseEntity {
 
-	@Column(name = "visit_date")
+	@Column("visit_date")
 	@DateTimeFormat(pattern = "yyyy-MM-dd")
 	private LocalDate date;
 
+	@Column("description")
 	@NotBlank
 	private String description;
+
+	@Column("pet_id")
+	private Integer petId;
 
 	/**
 	 * Creates a new instance of Visit for the current date
@@ -63,6 +65,14 @@ public class Visit extends BaseEntity {
 
 	public void setDescription(String description) {
 		this.description = description;
+	}
+
+	public Integer getPetId() {
+		return this.petId;
+	}
+
+	public void setPetId(Integer petId) {
+		this.petId = petId;
 	}
 
 }

--- a/src/main/java/org/springframework/samples/petclinic/owner/VisitController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/VisitController.java
@@ -62,7 +62,7 @@ class VisitController {
 	@ModelAttribute("visit")
 	public Visit loadPetWithVisit(@PathVariable("ownerId") int ownerId, @PathVariable("petId") int petId,
 			Map<String, Object> model) {
-		Optional<Owner> optionalOwner = owners.findById(ownerId);
+		Optional<Owner> optionalOwner = owners.findById(ownerId).blockOptional();
 		Owner owner = optionalOwner.orElseThrow(() -> new IllegalArgumentException(
 				"Owner not found with id: " + ownerId + ". Please ensure the ID is correct "));
 
@@ -92,7 +92,7 @@ class VisitController {
 		}
 
 		owner.addVisit(petId, visit);
-		this.owners.save(owner);
+		this.owners.save(owner).block();
 		redirectAttributes.addFlashAttribute("message", "Your visit has been booked");
 		return "redirect:/owners/{ownerId}";
 	}

--- a/src/main/java/org/springframework/samples/petclinic/owner/VisitRepository.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/VisitRepository.java
@@ -13,26 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.springframework.samples.petclinic.owner;
 
-import org.springframework.data.r2dbc.repository.Query;
 import org.springframework.data.r2dbc.repository.R2dbcRepository;
 import reactor.core.publisher.Flux;
 
-/**
- * Repository class for <code>PetType</code> domain objects.
- *
- * @author Patrick Baumgartner
- */
+public interface VisitRepository extends R2dbcRepository<Visit, Integer> {
 
-public interface PetTypeRepository extends R2dbcRepository<PetType, Integer> {
-
-	/**
-	 * Retrieve all {@link PetType}s from the data store ordered by name.
-	 * @return a Flux of {@link PetType}s.
-	 */
-	@Query("SELECT ptype FROM PetType ptype ORDER BY ptype.name")
-	Flux<PetType> findPetTypes();
+	Flux<Visit> findByPetId(Integer petId);
 
 }

--- a/src/main/java/org/springframework/samples/petclinic/system/CaffeineCacheManagerConfiguration.java
+++ b/src/main/java/org/springframework/samples/petclinic/system/CaffeineCacheManagerConfiguration.java
@@ -13,26 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.springframework.samples.petclinic.system;
 
-package org.springframework.samples.petclinic.owner;
+import org.springframework.boot.autoconfigure.cache.CacheManagerCustomizer;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 
-import org.springframework.data.r2dbc.repository.Query;
-import org.springframework.data.r2dbc.repository.R2dbcRepository;
-import reactor.core.publisher.Flux;
+@Configuration
+public class CaffeineCacheManagerConfiguration {
 
-/**
- * Repository class for <code>PetType</code> domain objects.
- *
- * @author Patrick Baumgartner
- */
-
-public interface PetTypeRepository extends R2dbcRepository<PetType, Integer> {
-
-	/**
-	 * Retrieve all {@link PetType}s from the data store ordered by name.
-	 * @return a Flux of {@link PetType}s.
-	 */
-	@Query("SELECT ptype FROM PetType ptype ORDER BY ptype.name")
-	Flux<PetType> findPetTypes();
+	@Bean
+	public CacheManagerCustomizer<CaffeineCacheManager> caffeineCacheManagerCustomizer() {
+		return cacheManager -> cacheManager.setAsyncCacheMode(true);
+	}
 
 }

--- a/src/main/java/org/springframework/samples/petclinic/vet/Specialty.java
+++ b/src/main/java/org/springframework/samples/petclinic/vet/Specialty.java
@@ -15,18 +15,15 @@
  */
 package org.springframework.samples.petclinic.vet;
 
+import org.springframework.data.relational.core.mapping.Table;
 import org.springframework.samples.petclinic.model.NamedEntity;
-
-import jakarta.persistence.Entity;
-import jakarta.persistence.Table;
 
 /**
  * Models a {@link Vet Vet's} specialty (for example, dentistry).
  *
  * @author Juergen Hoeller
  */
-@Entity
-@Table(name = "specialties")
+@Table("specialties")
 public class Specialty extends NamedEntity {
 
 }

--- a/src/main/java/org/springframework/samples/petclinic/vet/Vet.java
+++ b/src/main/java/org/springframework/samples/petclinic/vet/Vet.java
@@ -21,15 +21,11 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.springframework.data.annotation.Transient;
+import org.springframework.data.relational.core.mapping.Table;
 import org.springframework.samples.petclinic.model.NamedEntity;
 import org.springframework.samples.petclinic.model.Person;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.JoinTable;
-import jakarta.persistence.ManyToMany;
-import jakarta.persistence.Table;
 import jakarta.xml.bind.annotation.XmlElement;
 
 /**
@@ -40,13 +36,10 @@ import jakarta.xml.bind.annotation.XmlElement;
  * @author Sam Brannen
  * @author Arjen Poutsma
  */
-@Entity
-@Table(name = "vets")
+@Table("vets")
 public class Vet extends Person {
 
-	@ManyToMany(fetch = FetchType.EAGER)
-	@JoinTable(name = "vet_specialties", joinColumns = @JoinColumn(name = "vet_id"),
-			inverseJoinColumns = @JoinColumn(name = "specialty_id"))
+	@Transient
 	private Set<Specialty> specialties;
 
 	protected Set<Specialty> getSpecialtiesInternal() {

--- a/src/main/java/org/springframework/samples/petclinic/vet/VetController.java
+++ b/src/main/java/org/springframework/samples/petclinic/vet/VetController.java
@@ -46,24 +46,23 @@ class VetController {
 		// Here we are returning an object of type 'Vets' rather than a collection of Vet
 		// objects so it is simpler for Object-Xml mapping
 		Vets vets = new Vets();
-		Page<Vet> paginated = findPaginated(page);
-		vets.getVetList().addAll(paginated.toList());
+		List<Vet> paginated = findPaginated(page);
+		vets.getVetList().addAll(paginated);
 		return addPaginationModel(page, paginated, model);
 	}
 
-	private String addPaginationModel(int page, Page<Vet> paginated, Model model) {
-		List<Vet> listVets = paginated.getContent();
+	private String addPaginationModel(int page, List<Vet> listVets, Model model) {
 		model.addAttribute("currentPage", page);
-		model.addAttribute("totalPages", paginated.getTotalPages());
-		model.addAttribute("totalItems", paginated.getTotalElements());
+		// model.addAttribute("totalPages", paginated.getTotalPages());
+		// model.addAttribute("totalItems", paginated.getTotalElements());
 		model.addAttribute("listVets", listVets);
 		return "vets/vetList";
 	}
 
-	private Page<Vet> findPaginated(int page) {
+	private List<Vet> findPaginated(int page) {
 		int pageSize = 5;
 		Pageable pageable = PageRequest.of(page - 1, pageSize);
-		return vetRepository.findAll(pageable);
+		return vetRepository.findAllBy(pageable).collectList().block();
 	}
 
 	@GetMapping({ "/vets" })
@@ -71,7 +70,7 @@ class VetController {
 		// Here we are returning an object of type 'Vets' rather than a collection of Vet
 		// objects so it is simpler for JSon/Object mapping
 		Vets vets = new Vets();
-		vets.getVetList().addAll(this.vetRepository.findAll());
+		vets.getVetList().addAll(this.vetRepository.findAll().collectList().block());
 		return vets;
 	}
 

--- a/src/main/java/org/springframework/samples/petclinic/vet/VetRepository.java
+++ b/src/main/java/org/springframework/samples/petclinic/vet/VetRepository.java
@@ -16,43 +16,37 @@
 package org.springframework.samples.petclinic.vet;
 
 import org.springframework.cache.annotation.Cacheable;
-import org.springframework.dao.DataAccessException;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.repository.Repository;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Collection;
+import org.springframework.data.r2dbc.repository.Query;
+import org.springframework.data.r2dbc.repository.R2dbcRepository;
+import reactor.core.publisher.Flux;
 
 /**
  * Repository class for <code>Vet</code> domain objects All method names are compliant
  * with Spring Data naming conventions so this interface can easily be extended for Spring
  * Data. See:
- * https://docs.spring.io/spring-data/jpa/docs/current/reference/html/#repositories.query-methods.query-creation
+ * https://docs.spring.io/spring-data/r2dbc/docs/current/reference/html/#repositories
  *
  * @author Ken Krebs
  * @author Juergen Hoeller
  * @author Sam Brannen
  * @author Michael Isvy
  */
-public interface VetRepository extends Repository<Vet, Integer> {
+public interface VetRepository extends R2dbcRepository<Vet, Integer> {
 
 	/**
 	 * Retrieve all <code>Vet</code>s from the data store.
-	 * @return a <code>Collection</code> of <code>Vet</code>s
+	 * @return a <code>Flux</code> of <code>Vet</code>s
 	 */
-	@Transactional(readOnly = true)
 	@Cacheable("vets")
-	Collection<Vet> findAll() throws DataAccessException;
+	Flux<Vet> findAll();
 
 	/**
-	 * Retrieve all <code>Vet</code>s from data store in Pages
-	 * @param pageable
-	 * @return
-	 * @throws DataAccessException
+	 * Retrieve all <code>Vet</code>s from data store with pagination
+	 * @param pageable pagination information
+	 * @return a <code>Flux</code> of <code>Vet</code>s
 	 */
-	@Transactional(readOnly = true)
 	@Cacheable("vets")
-	Page<Vet> findAll(Pageable pageable) throws DataAccessException;
+	Flux<Vet> findAllBy(Pageable pageable);
 
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,10 +6,10 @@ spring.sql.init.data-locations=classpath*:db/${database}/data.sql
 # Web
 spring.thymeleaf.mode=HTML
 
-# JPA
-spring.jpa.hibernate.ddl-auto=none
-spring.jpa.open-in-view=false
-
+# R2DBC
+spring.r2dbc.generate-unique-name=false
+spring.r2dbc.name=petclinic
+spring.data.r2dbc.repositories.enabled=true
 # Internationalization
 spring.messages.basename=messages/messages
 

--- a/src/test/java/org/springframework/samples/petclinic/PetClinicIntegrationTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/PetClinicIntegrationTests.java
@@ -17,6 +17,7 @@
 package org.springframework.samples.petclinic;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -45,8 +46,13 @@ public class PetClinicIntegrationTests {
 
 	@Test
 	void testFindAll() {
-		vets.findAll();
-		vets.findAll(); // served from cache
+		// First call to populate cache
+		var allVets = vets.findAll().collectList().block();
+		var cachedVets = vets.findAll().collectList().block();
+
+		for (int i = 0; i < allVets.size(); i++) {
+			assertSame(allVets.get(i), cachedVets.get(i));
+		}
 	}
 
 	@Test

--- a/src/test/java/org/springframework/samples/petclinic/owner/PetControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/owner/PetControllerTests.java
@@ -24,16 +24,15 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
-import org.springframework.samples.petclinic.owner.PetTypeRepository;
-import org.springframework.samples.petclinic.owner.OwnerRepository;
 import org.springframework.test.context.aot.DisabledInAotMode;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import java.time.LocalDate;
-import java.util.List;
-import java.util.Optional;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -71,7 +70,7 @@ class PetControllerTests {
 		PetType cat = new PetType();
 		cat.setId(3);
 		cat.setName("hamster");
-		given(this.types.findPetTypes()).willReturn(List.of(cat));
+		given(this.types.findPetTypes()).willReturn(Flux.just(cat));
 
 		Owner owner = new Owner();
 		Pet pet = new Pet();
@@ -82,7 +81,7 @@ class PetControllerTests {
 		dog.setId(TEST_PET_ID + 1);
 		pet.setName("petty");
 		dog.setName("doggy");
-		given(this.owners.findById(TEST_OWNER_ID)).willReturn(Optional.of(owner));
+		given(this.owners.findById(TEST_OWNER_ID)).willReturn(Mono.just(owner));
 	}
 
 	@Test
@@ -95,6 +94,10 @@ class PetControllerTests {
 
 	@Test
 	void testProcessCreationFormSuccess() throws Exception {
+		var newOwner = new Owner();
+		newOwner.setId(TEST_OWNER_ID);
+		given(this.owners.save(any(Owner.class))).willReturn(Mono.just(new Owner()));
+
 		mockMvc
 			.perform(post("/owners/{ownerId}/pets/new", TEST_OWNER_ID).param("name", "Betty")
 				.param("type", "hamster")
@@ -173,6 +176,10 @@ class PetControllerTests {
 
 	@Test
 	void testProcessUpdateFormSuccess() throws Exception {
+		var newOwner = new Owner();
+		newOwner.setId(TEST_OWNER_ID);
+		given(this.owners.save(any(Owner.class))).willReturn(Mono.just(new Owner()));
+
 		mockMvc
 			.perform(post("/owners/{ownerId}/pets/{petId}/edit", TEST_OWNER_ID, TEST_PET_ID).param("name", "Betty")
 				.param("type", "hamster")

--- a/src/test/java/org/springframework/samples/petclinic/owner/PetTypeFormatterTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/owner/PetTypeFormatterTests.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.condition.DisabledInNativeImage;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Flux;
 
 /**
  * Test class for {@link PetTypeFormatter}
@@ -79,7 +80,7 @@ class PetTypeFormatterTests {
 	 * Helper method to produce some sample pet types just for test purpose
 	 * @return {@link Collection} of {@link PetType}
 	 */
-	private List<PetType> makePetTypes() {
+	private Flux<PetType> makePetTypes() {
 		List<PetType> petTypes = new ArrayList<>();
 		petTypes.add(new PetType() {
 			{
@@ -91,7 +92,7 @@ class PetTypeFormatterTests {
 				setName("Bird");
 			}
 		});
-		return petTypes;
+		return Flux.fromIterable(petTypes);
 	}
 
 }

--- a/src/test/java/org/springframework/samples/petclinic/owner/R2dbcOwnerRepositoryTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/owner/R2dbcOwnerRepositoryTests.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2012-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.samples.petclinic.owner;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.r2dbc.DataR2dbcTest;
+import org.springframework.data.domain.PageRequest;
+import reactor.test.StepVerifier;
+
+@DataR2dbcTest
+class R2dbcOwnerRepositoryTests {
+
+	@Autowired
+	private OwnerRepository ownerRepository;
+
+	@Test
+	void shouldFindOwnersByLastName() {
+		// Create a test owner
+		Owner owner = new Owner();
+		owner.setFirstName("John");
+		owner.setLastName("Doe");
+		owner.setAddress("123 Main St");
+		owner.setCity("Anytown");
+		owner.setTelephone("1234567890");
+
+		// Save the owner and then find by last name
+		ownerRepository.save(owner)
+			.then(ownerRepository.findByLastNameStartingWith("Doe", PageRequest.of(0, 10)).collectList())
+			.as(StepVerifier::create)
+			.expectNextMatches(owners -> {
+				// Verify we found at least one owner with last name starting with "Doe"
+				return !owners.isEmpty() && owners.stream().anyMatch(o -> o.getLastName().startsWith("Doe"));
+			})
+			.verifyComplete();
+	}
+
+	@Test
+	void shouldFindOwnerById() {
+		// Create a test owner
+		Owner owner = new Owner();
+		owner.setFirstName("Jane");
+		owner.setLastName("Smith");
+		owner.setAddress("456 Oak St");
+		owner.setCity("Somewhere");
+		owner.setTelephone("0987654321");
+
+		// Save the owner and then find by ID
+		ownerRepository.save(owner)
+			.flatMap(savedOwner -> ownerRepository.findById(savedOwner.getId()))
+			.as(StepVerifier::create)
+			.expectNextMatches(foundOwner -> foundOwner.getFirstName().equals("Jane")
+					&& foundOwner.getLastName().equals("Smith") && foundOwner.getAddress().equals("456 Oak St")
+					&& foundOwner.getCity().equals("Somewhere") && foundOwner.getTelephone().equals("0987654321"))
+			.verifyComplete();
+	}
+
+}

--- a/src/test/java/org/springframework/samples/petclinic/owner/R2dbcPetRepositoryTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/owner/R2dbcPetRepositoryTests.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2012-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.samples.petclinic.owner;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.r2dbc.DataR2dbcTest;
+import reactor.test.StepVerifier;
+
+import java.util.Set;
+
+@DataR2dbcTest
+class R2dbcPetRepositoryTests {
+
+	@Autowired
+	private PetRepository petRepository;
+
+	@Test
+	void shouldFindPetsByOwnerId() {
+		petRepository.findByOwnerId(6).collectList().as(StepVerifier::create).expectNextMatches(pets -> {
+			if (pets == null || pets.isEmpty())
+				return false;
+			Set<String> names = pets.stream().map(Pet::getName).collect(java.util.stream.Collectors.toSet());
+			return names.contains("Samantha") && names.contains("Max") && pets.size() == 2;
+		}).verifyComplete();
+	}
+
+	@Test
+	void shouldFindPetByIdAndOwnerId() {
+		petRepository.findByIdAndOwnerId(7, 6)
+			.as(StepVerifier::create)
+			.expectNextMatches(
+					pet -> pet != null && pet.getId() == 7 && pet.getOwnerId() == 6 && "Samantha".equals(pet.getName()))
+			.verifyComplete();
+	}
+
+}

--- a/src/test/java/org/springframework/samples/petclinic/owner/R2dbcVisitRepositoryTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/owner/R2dbcVisitRepositoryTests.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2012-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.samples.petclinic.owner;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.r2dbc.DataR2dbcTest;
+import reactor.test.StepVerifier;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@DataR2dbcTest
+class R2dbcVisitRepositoryTests {
+
+	@Autowired
+	private VisitRepository visitRepository;
+
+	@Test
+	void shouldFindVisitsByPetId() {
+		visitRepository.findByPetId(7).collectList().as(StepVerifier::create).expectNextMatches(visits -> {
+			if (visits == null)
+				return false;
+			Set<String> descriptions = visits.stream().map(Visit::getDescription).collect(Collectors.toSet());
+			return visits.size() == 2 && descriptions.contains("rabies shot") && descriptions.contains("spayed")
+					&& visits.stream().allMatch(v -> v.getPetId() == 7);
+		}).verifyComplete();
+	}
+
+	@Test
+	void shouldReturnEmptyWhenNoVisitsForPetId() {
+		visitRepository.findByPetId(1)
+			.collectList()
+			.as(StepVerifier::create)
+			.expectNextMatches(java.util.List::isEmpty)
+			.verifyComplete();
+	}
+
+}

--- a/src/test/java/org/springframework/samples/petclinic/owner/VisitControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/owner/VisitControllerTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.samples.petclinic.owner;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -31,6 +32,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.context.aot.DisabledInAotMode;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+import reactor.core.publisher.Mono;
 
 import java.util.Optional;
 
@@ -61,7 +63,7 @@ class VisitControllerTests {
 		Pet pet = new Pet();
 		owner.addPet(pet);
 		pet.setId(TEST_PET_ID);
-		given(this.owners.findById(TEST_OWNER_ID)).willReturn(Optional.of(owner));
+		given(this.owners.findById(TEST_OWNER_ID)).willReturn(Mono.just(owner));
 	}
 
 	@Test
@@ -73,6 +75,10 @@ class VisitControllerTests {
 
 	@Test
 	void testProcessNewVisitFormSuccess() throws Exception {
+		var newOwner = new Owner();
+		newOwner.setId(TEST_OWNER_ID);
+		given(this.owners.save(any(Owner.class))).willReturn(Mono.just(new Owner()));
+
 		mockMvc
 			.perform(post("/owners/{ownerId}/pets/{petId}/visits/new", TEST_OWNER_ID, TEST_PET_ID)
 				.param("name", "George")

--- a/src/test/java/org/springframework/samples/petclinic/service/EntityUtils.java
+++ b/src/test/java/org/springframework/samples/petclinic/service/EntityUtils.java
@@ -16,7 +16,6 @@
 
 package org.springframework.samples.petclinic.service;
 
-import org.springframework.orm.ObjectRetrievalFailureException;
 import org.springframework.samples.petclinic.model.BaseEntity;
 
 import java.util.Collection;
@@ -38,16 +37,15 @@ public abstract class EntityUtils {
 	 * @param entityClass the entity class to look up
 	 * @param entityId the entity id to look up
 	 * @return the found entity
-	 * @throws ObjectRetrievalFailureException if the entity was not found
+	 * @throws IllegalArgumentException if the entity was not found
 	 */
-	public static <T extends BaseEntity> T getById(Collection<T> entities, Class<T> entityClass, int entityId)
-			throws ObjectRetrievalFailureException {
+	public static <T extends BaseEntity> T getById(Collection<T> entities, Class<T> entityClass, int entityId) {
 		for (T entity : entities) {
 			if (entity.getId() == entityId && entityClass.isInstance(entity)) {
 				return entity;
 			}
 		}
-		throw new ObjectRetrievalFailureException(entityClass, entityId);
+		throw new IllegalArgumentException();
 	}
 
 }

--- a/src/test/java/org/springframework/samples/petclinic/system/CrashControllerIntegrationTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/system/CrashControllerIntegrationTests.java
@@ -39,6 +39,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.RequestEntity;
 import org.springframework.http.ResponseEntity;
+import reactor.core.publisher.Flux;
 
 /**
  * Integration Test for {@link CrashController}.

--- a/src/test/java/org/springframework/samples/petclinic/vet/R2dbcVetRepositoryTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/vet/R2dbcVetRepositoryTests.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2012-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.samples.petclinic.vet;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.r2dbc.DataR2dbcTest;
+import org.springframework.data.domain.PageRequest;
+import reactor.test.StepVerifier;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@DataR2dbcTest
+class R2dbcVetRepositoryTests {
+
+	@Autowired
+	private VetRepository vetRepository;
+
+	@Test
+	void shouldFindAllVets() {
+		vetRepository.findAll()
+			.collectList()
+			.as(StepVerifier::create)
+			.expectNextMatches(vets -> vets != null && vets.size() == 6
+					&& vets.stream()
+						.map(Vet::getLastName)
+						.collect(Collectors.toSet())
+						.containsAll(Set.of("Carter", "Leary", "Douglas", "Ortega", "Stevens", "Jenkins")))
+			.verifyComplete();
+	}
+
+	@Test
+	void shouldFindAllVetsWithPagination() {
+		vetRepository.findAllBy(PageRequest.of(0, 3))
+			.collectList()
+			.as(StepVerifier::create)
+			.expectNextMatches(page -> page != null && page.size() == 3)
+			.verifyComplete();
+	}
+
+}

--- a/src/test/java/org/springframework/samples/petclinic/vet/VetControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/vet/VetControllerTests.java
@@ -30,6 +30,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import reactor.core.publisher.Flux;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -73,9 +74,8 @@ class VetControllerTests {
 
 	@BeforeEach
 	void setup() {
-		given(this.vets.findAll()).willReturn(Lists.newArrayList(james(), helen()));
-		given(this.vets.findAll(any(Pageable.class)))
-			.willReturn(new PageImpl<Vet>(Lists.newArrayList(james(), helen())));
+		given(this.vets.findAll()).willReturn(Flux.just(james(), helen()));
+		given(this.vets.findAllBy(any(Pageable.class))).willReturn(Flux.just(james(), helen()));
 
 	}
 


### PR DESCRIPTION
Start the migration to a reactive stack by transitioning the persistence layer from JPA to R2DBC.
At this step, we keep the controllers blocking using Spring MVC. Migration to spring-webflux controllers will happen in a later phase.
* Migrate JPA Entities to R2DBC Entities
* Replace JpaRepository with R2dbcRepository
